### PR TITLE
Fix the local authentication

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_API_ORIGIN = "http://127.0.0.1:8000"
+VITE_API_ORIGIN = "http://localhost:8000"

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -2,6 +2,6 @@ import axios from "axios"
 
 
 export const api = axios.create({
-    baseURL: `${import.meta.env.VITE_API_ORIGIN}/api`
+    baseURL: `${import.meta.env.VITE_API_ORIGIN}/api`,
+    withCredentials: true
 })
-


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2023-08-10T16:01:36Z" title="Thursday, August 10th 2023, 6:01:36 pm +02:00">Aug 10, 2023</time>_
_Merged <time datetime="2023-08-11T07:15:28Z" title="Friday, August 11th 2023, 9:15:28 am +02:00">Aug 11, 2023</time>_
---

The session cookie was not properly set by the server due to the CORS policy. So every requests after the authentication was failing, as the server wouldn't recognize the user.
Easy fix for the local environment: set the exact same domain name for the API calls than the Vite server. Even if localhost points the the same directory than 127.0.0.1, the browser don't consider them as equivalent, as the URL is different.
The Access-Control-Allow-Credentials header was also needed, server-side and client-side (the `withCredentials` parameter in Axios).