### PR TITLE
change the link on the comment author profile to not have the date in…

### DIFF
--- a/src/components/Comment/index.jsx
+++ b/src/components/Comment/index.jsx
@@ -21,11 +21,9 @@ function Comment({ author,text,createdAt}) {
                 </Link>
             </ListItemAvatar>
             <Paper className="c-comment-list__paper" >
-                <Link to={`/${author.organizationId}/user/${author.id}`}>
-                    <Typography variant="body2">
-                        {`${author.name}  ${author.surname} - ${date} à ${time}`}
-                    </Typography>
-                </Link>
+                <Typography variant="body2">
+                    <Link to={`/${author.organizationId}/user/${author.id}`}>{`${author.name} ${author.surname}`}</Link> - {date} à {time} 
+                </Typography>              
                 <Typography variant="body2">
                     {author.job}
                 </Typography>


### PR DESCRIPTION
> [<img alt="RodrianVANDERSMIT" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/124170906?s=40&v=4">](/RodrianVANDERSMIT) **Authored by [RodrianVANDERSMIT](/RodrianVANDERSMIT)**
_<time datetime="2023-08-15T15:05:02Z" title="Tuesday, August 15th 2023, 5:05:02 pm +02:00">Aug 15, 2023</time>_
_Merged <time datetime="2023-08-15T15:05:13Z" title="Tuesday, August 15th 2023, 5:05:13 pm +02:00">Aug 15, 2023</time>_
---

change the link on the comment author profile to not have the date inside