### PR TITLE
Crash when switching profile page

### DIFF
--- a/src/components/Feed/index.jsx
+++ b/src/components/Feed/index.jsx
@@ -37,7 +37,7 @@ function Feed({userIdUrl}) {
         return () => {
             dispatch(cleanFeedState())
         }
-    }, []);
+    }, [userIdUrl]);
 
     const handleScroll = () => {
         if (!isLoading && availablePosts === true &&


### PR DESCRIPTION
> [<img alt="RodrianVANDERSMIT" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/124170906?s=40&v=4">](/RodrianVANDERSMIT) **Authored by [RodrianVANDERSMIT](/RodrianVANDERSMIT)**
_<time datetime="2023-08-18T11:40:26Z" title="Friday, August 18th 2023, 1:40:26 pm +02:00">Aug 18, 2023</time>_
_Merged <time datetime="2023-08-18T11:40:38Z" title="Friday, August 18th 2023, 1:40:38 pm +02:00">Aug 18, 2023</time>_
---

cleanFeedState wasn't dispatched when switching profile page, adding the userIdUrl as a dependency of the useEffect solved the problem.