### PR TITLE
API authentication routes refactoring

### DIFF
--- a/src/redux/thunks/user.js
+++ b/src/redux/thunks/user.js
@@ -4,7 +4,7 @@ import { api } from "../../services/api"
 export const login = createAsyncThunk("users/login", async (credentials, thunkApi) => {
 
     try {
-        const { data } = await api.post('/users/session', {email: credentials.email, password: credentials.password} )
+        const { data } = await api.post('/session', {email: credentials.email, password: credentials.password} )
 
         const user = data
         return user
@@ -34,7 +34,7 @@ export const login = createAsyncThunk("users/login", async (credentials, thunkAp
 export const logout = createAsyncThunk("users/logout", async ( thunkApi) => {
 
     try {
-        const { data } = await api.delete('/users/session', )
+        const { data } = await api.delete('/session', )
 
         const user = data
         return user


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2023-08-28T16:11:51Z" title="Monday, August 28th 2023, 6:11:51 pm +02:00">Aug 28, 2023</time>_
_Merged <time datetime="2023-08-29T07:51:18Z" title="Tuesday, August 29th 2023, 9:51:18 am +02:00">Aug 29, 2023</time>_
---

Those routes have been simplified server-side, to remove the unnecessary `/users` prefix.