### PR TITLE
Lighter user profile request

### DIFF
--- a/src/components/Admin/AdminMembers/index.jsx
+++ b/src/components/Admin/AdminMembers/index.jsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import { fetchMembers } from '../../../redux/thunks/members';
 import { getMembersList, getMembersLoader } from '../../../redux/selectors/members';
 import { getUserOrganizationId } from '../../../redux/selectors/user';
+import { cleanMembersState } from '../../../redux/reducers/members';
 
 import './style.scss'
 
@@ -25,6 +26,10 @@ function AdminMembers () {
         }
         else {
             console.log("membres introuvable")
+        }
+
+        return () => {
+            dispatch(cleanMembersState());
         }
     }, [organizationId, dispatch])
 

--- a/src/components/Cards/SelectedUserCard/index.jsx
+++ b/src/components/Cards/SelectedUserCard/index.jsx
@@ -21,7 +21,7 @@ function SelectedUserCard() {
                 setIsLoading(false)
             }
             catch {
-                console.log("membres introuvable");
+                console.log("membre introuvable");
             }
         }
 

--- a/src/components/Cards/SelectedUserCard/index.jsx
+++ b/src/components/Cards/SelectedUserCard/index.jsx
@@ -1,32 +1,29 @@
 import { useParams } from "react-router-dom";
 import { Avatar, Box, Typography } from "@mui/material";
-import { useDispatch, useSelector } from "react-redux";
-import { getMembers } from "../../../redux/selectors/members";
-import { getUserOrganizationId } from "../../../redux/selectors/user";
-import { useEffect } from "react";
-import { fetchMembers } from "../../../redux/thunks/members";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Link as MuiLink } from '@mui/material'
+import { api } from "../../../services/api";
 
 import './style.scss'
 
 function SelectedUserCard() {
-    const dispatch = useDispatch();
     const userId = parseInt(useParams().userId, 10);
-
-    const membersState = useSelector(getMembers);
-    const membersList = membersState.list;
-    const selectedMember = membersList.find((member) => member.id === userId);
-
-    const organizationId = useSelector(getUserOrganizationId);
+    const [selectedMember, setSelectedMember] = useState(null);
 
     useEffect(() => {
-        if (organizationId) {
-            dispatch(fetchMembers(organizationId));
-        } else {
-            console.log("membres introuvable");
+        const fetchUser = async () => {
+            try {
+                const res = await api(`/users/${userId}`)
+                setSelectedMember(res.data)
+            }
+            catch {
+                console.log("membres introuvable");
+            }
         }
-    }, [organizationId, dispatch]);
+
+        fetchUser();
+    }, [userId]);
 
     if (!selectedMember) {
         return (

--- a/src/components/Cards/SelectedUserCard/index.jsx
+++ b/src/components/Cards/SelectedUserCard/index.jsx
@@ -10,12 +10,15 @@ import './style.scss'
 function SelectedUserCard() {
     const userId = parseInt(useParams().userId, 10);
     const [selectedMember, setSelectedMember] = useState(null);
+    const [isLoading, setIsLoading] = useState(true)
 
     useEffect(() => {
         const fetchUser = async () => {
             try {
+                setIsLoading(true)
                 const res = await api(`/users/${userId}`)
                 setSelectedMember(res.data)
+                setIsLoading(false)
             }
             catch {
                 console.log("membres introuvable");
@@ -24,6 +27,10 @@ function SelectedUserCard() {
 
         fetchUser();
     }, [userId]);
+
+    if (isLoading) {
+        return "";
+    }
 
     if (!selectedMember) {
         return (

--- a/src/components/Cards/SelectedUserCard/index.jsx
+++ b/src/components/Cards/SelectedUserCard/index.jsx
@@ -64,28 +64,28 @@ function SelectedUserCard() {
                         mx: 'auto'
                     }}
                 />
-            <Box
-                className= "c-user-card__info"
-                sx= {{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    pb: 1
-                }}
-            >
-                <Typography
-                    className= "c-user-card__identity"
-                    variant= "body1"
+                <Box
+                    className= "c-user-card__info"
+                    sx= {{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        pb: 1
+                    }}
                 >
-                    {selectedMember.name} {selectedMember.surname}
-                </Typography>
-                <Typography
-                    className= "c-user-card__job"
-                    variant= "body1"
-                >
-                    {selectedMember.job}
-                </Typography>
-            </Box>
+                    <Typography
+                        className= "c-user-card__identity"
+                        variant= "body1"
+                    >
+                        {selectedMember.name} {selectedMember.surname}
+                    </Typography>
+                    <Typography
+                        className= "c-user-card__job"
+                        variant= "body1"
+                    >
+                        {selectedMember.job}
+                    </Typography>
+                </Box>
             </MuiLink>
         </Box>
     );

--- a/src/components/Cards/SelectedUserCard/index.jsx
+++ b/src/components/Cards/SelectedUserCard/index.jsx
@@ -12,12 +12,11 @@ import './style.scss'
 
 function SelectedUserCard() {
     const dispatch = useDispatch();
-    const { userId } = useParams();
-    const userIdUrl = parseInt(userId, 10);
+    const userId = parseInt(useParams().userId, 10);
 
     const membersState = useSelector(getMembers);
     const membersList = membersState.list;
-    const selectedMember = membersList.find((member) => member.id === userIdUrl);
+    const selectedMember = membersList.find((member) => member.id === userId);
 
     const organizationId = useSelector(getUserOrganizationId);
 

--- a/src/components/Nav/DesktopMenu/index.jsx
+++ b/src/components/Nav/DesktopMenu/index.jsx
@@ -4,7 +4,6 @@ import { Link, useNavigate } from 'react-router-dom'
 import { getUserId, getUserOrganizationId } from "../../../redux/selectors/user"
 import {logout}  from "../../../redux/reducers/user"
 import { cleanOrganizationState } from "../../../redux/reducers/organization"
-import { cleanFeedState } from "../../../redux/reducers/feed"
 import { Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import ContactMailIcon from '@mui/icons-material/ContactMail';

--- a/src/components/Nav/DesktopMenu/index.jsx
+++ b/src/components/Nav/DesktopMenu/index.jsx
@@ -4,7 +4,6 @@ import { Link, useNavigate } from 'react-router-dom'
 import { getUserId, getUserOrganizationId } from "../../../redux/selectors/user"
 import {logout}  from "../../../redux/reducers/user"
 import { cleanOrganizationState } from "../../../redux/reducers/organization"
-import { cleanMembersState } from "../../../redux/reducers/members"
 import { cleanFeedState } from "../../../redux/reducers/feed"
 import { Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
@@ -26,7 +25,6 @@ const DesktopMenu = () => {
         navigate('/')
 
         dispatch(cleanOrganizationState());
-        dispatch(cleanMembersState());
     }
 
     

--- a/src/components/Nav/MobileMenu/index.jsx
+++ b/src/components/Nav/MobileMenu/index.jsx
@@ -5,7 +5,6 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import { getIsLogged, getUserId, getUserOrganizationId } from '../../../redux/selectors/user';
 import { cleanOrganizationState } from '../../../redux/reducers/organization';
-import { cleanMembersState } from '../../../redux/reducers/members';
 import { cleanFeedState } from '../../../redux/reducers/feed';
 import { logout } from '../../../redux/reducers/user';
 
@@ -41,7 +40,6 @@ export default function MobileMenu() {
         navigate('/')
 
         dispatch(cleanOrganizationState());
-        dispatch(cleanMembersState());
     }
 
     return (

--- a/src/components/Nav/MobileMenu/index.jsx
+++ b/src/components/Nav/MobileMenu/index.jsx
@@ -5,7 +5,6 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import { getIsLogged, getUserId, getUserOrganizationId } from '../../../redux/selectors/user';
 import { cleanOrganizationState } from '../../../redux/reducers/organization';
-import { cleanFeedState } from '../../../redux/reducers/feed';
 import { logout } from '../../../redux/reducers/user';
 
 


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2023-09-07T15:33:40Z" title="Thursday, September 7th 2023, 5:33:40 pm +02:00">Sep 7, 2023</time>_
_Merged <time datetime="2023-09-08T08:33:15Z" title="Friday, September 8th 2023, 10:33:15 am +02:00">Sep 8, 2023</time>_
---

All organization users was fetched to extract the one of the profile, which could have been really bad in a big organization. It was just a residue of the treatments with the mocked data.
Due to this, some refactoring became possible, like the centralization of the cleaning of the members state.