### PR TITLE
User organization ID fix

### DIFF
--- a/src/components/Cards/SelectedUserCard/index.jsx
+++ b/src/components/Cards/SelectedUserCard/index.jsx
@@ -54,7 +54,7 @@ function SelectedUserCard() {
         >
             <MuiLink 
                 component={Link}
-                to={`/${selectedMember.organizationId}/user/${selectedMember.id}`}
+                to={`/${selectedMember.organization.id}/user/${selectedMember.id}`}
             >
                 <Avatar
                     className= "c-user-card__avatar"

--- a/src/components/Cards/UserCard/index.jsx
+++ b/src/components/Cards/UserCard/index.jsx
@@ -12,7 +12,7 @@ function UserCard() {
     return (
         <MuiLink 
             component={Link}
-            to={`/${userLogged.organizationId}/user/${userLogged.id}`}
+            to={`/${userLogged.organization.id}/user/${userLogged.id}`}
         >
             <Box
                 className= "c-user-card__group"

--- a/src/components/Comment/index.jsx
+++ b/src/components/Comment/index.jsx
@@ -17,14 +17,14 @@ function Comment({ author,text,createdAt}) {
     return (
         <ListItem className="c-comment-list" alignItems="flex-start">
             <ListItemAvatar>
-                <Link to={`/${author.organizationId}/user/${author.id}`}>
+                <Link to={`/${author.organization.id}/user/${author.id}`}>
                     <Avatar alt="Remy Sharp" src={author.profilePicture} />
                 </Link>
             </ListItemAvatar>
             <Paper className="c-comment-list__paper" >
                 <MuiLink 
                     component={Link}
-                    to={`/${author.organizationId}/user/${author.id}`}
+                    to={`/${author.organization.id}/user/${author.id}`}
                 >
                     <Typography
                         className= "c-comment-list__identity"

--- a/src/components/Forms/LoginForm/index.jsx
+++ b/src/components/Forms/LoginForm/index.jsx
@@ -29,7 +29,7 @@ function LoginForm() {
     // Redirect user to organization page if he is logged in.
     useEffect(() => {
         if (isLog) {
-            const organizationId = loggedUser.organizationId
+            const organizationId = loggedUser.organization?.id
             
             if (organizationId){
                 navigate(`/${organizationId}`)

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -65,7 +65,7 @@ function Post({id, author,text,commentsCount,createdAt}) {
         >
             <CardHeader
                 avatar={
-                    <Link to={`/${userLogged.organizationId}/user/${author.id}`}>
+                    <Link to={`/${userLogged.organization.id}/user/${author.id}`}>
                         <Avatar className="c-avatar" alt="Remy Sharp" src={author.profilePicture} />
                     </Link>
                 }       
@@ -73,7 +73,7 @@ function Post({id, author,text,commentsCount,createdAt}) {
                     <>
                     <MuiLink 
                     component={Link}
-                    to={`/${userLogged.organizationId}/user/${author.id}`}
+                    to={`/${userLogged.organization.id}/user/${author.id}`}
                     >
                         <Typography
                         className= "c-card-post__identity"

--- a/src/redux/selectors/user.js
+++ b/src/redux/selectors/user.js
@@ -6,11 +6,10 @@ export const getIsLogged = state => getName(state) !== "";
 
 export const getUserError = state => getUser(state).error;
 
-export const getUserOrganizationId = state => getUser(state).organizationId;
+export const getUserOrganizationId = state => getUser(state).organization?.id;
 
 export const getUserId = state => getUser(state).id;
 
 export const getUserRole = state => getUser(state).role;
 
 export const getUserLoading = state => getUser(state).loading;
-

--- a/src/redux/thunks/feed.js
+++ b/src/redux/thunks/feed.js
@@ -5,7 +5,7 @@ import { api } from "../../services/api"
 export const fetchPosts = createAsyncThunk("feed/fetchPosts", async (userIdUrl, thunkApi) => {
 
     const currentPage = thunkApi.getState().feed.pagination.currentPage
-    const id = thunkApi.getState().user.organizationId;
+    const id = thunkApi.getState().user.organization?.id;
 
     try {
         const url = userIdUrl ?


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2023-09-11T07:28:43Z" title="Monday, September 11th 2023, 9:28:43 am +02:00">Sep 11, 2023</time>_
_Merged <time datetime="2023-09-11T07:31:38Z" title="Monday, September 11th 2023, 9:31:38 am +02:00">Sep 11, 2023</time>_
---

Instead of returning only the ID in each user resource, the API returns the full organization resource now. The front-end code needed to be adapted before coding the next refactoring, to avoid errors with the other teammates when they would try to update their back-end working copy.