### PR TITLE
Fix an error in console when creating a user

### DIFF
--- a/src/redux/thunks/user.js
+++ b/src/redux/thunks/user.js
@@ -73,13 +73,13 @@ export const addUser = createAsyncThunk("user/addUser", async (data, thunkAPI) =
         }
         formData.append('organizationId', organizationId)
 
-        const response = await api.post('/users',formData, {
+        const { data: user } = await api.post('/users',formData, {
             headers: {
                 'Content-Type': 'multipart/form-data'
             }
         })
 
-        return response
+        return user
     }
     catch (error) {
         return thunkAPI.rejectWithValue({status: 500, message: "Une erreur s'est produite"});


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2023-09-13T11:09:14Z" title="Wednesday, September 13th 2023, 1:09:14 pm +02:00">Sep 13, 2023</time>_
_Merged <time datetime="2023-09-13T11:10:17Z" title="Wednesday, September 13th 2023, 1:10:17 pm +02:00">Sep 13, 2023</time>_
---

In the user/addUser thunk, the full Axios response was returned to the reducer, instead of the data property. It was not a problem for the app, because these data are not used by the reducer, but an error was thrown due to some non-serializable content in the Axios response being sent to Redux.