### PR TITLE
401 error handling

### DIFF
--- a/src/components/Router/hook.js
+++ b/src/components/Router/hook.js
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api } from '../../services/api'
+
+export default function useInterceptors() {
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        // The first argument of that use() method is a callback to launch on
+        // success (code 2xx). We don't need that here so we only provide the
+        // error callback.
+        api.interceptors.response.use(null, error => {
+            // When a session expires, or the user logged out itself in another
+            // tab than the current one, or his/her account has been disabled
+            // while using the app... or a lot of possible scenarios, the next
+            // request will send back a 401 error.
+            if (error.response.status === 401) {
+                navigate('/')
+            }
+
+            return Promise.reject(error)
+        })
+    }, [])
+}

--- a/src/components/Router/hook.js
+++ b/src/components/Router/hook.js
@@ -1,8 +1,11 @@
 import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import { api } from '../../services/api'
+import { cleanUserState } from '../../redux/reducers/user'
 
 export default function useInterceptors() {
+    const dispatch = useDispatch()
     const navigate = useNavigate()
 
     useEffect(() => {
@@ -13,8 +16,10 @@ export default function useInterceptors() {
             // When a session expires, or the user logged out itself in another
             // tab than the current one, or his/her account has been disabled
             // while using the app... or a lot of possible scenarios, the next
-            // request will send back a 401 error.
+            // request will send back a 401 error. When it happens, we clean the
+            // user state and redirect to the home page.
             if (error.response.status === 401) {
+                dispatch(cleanUserState())
                 navigate('/')
             }
 

--- a/src/components/Router/index.jsx
+++ b/src/components/Router/index.jsx
@@ -13,8 +13,12 @@ import Error401 from '../../views/Error401'
 import Error403 from '../../views/Error403'
 import Error404 from '../../views/Error404'
 import Error500 from '../../views/Error500'
+import useInterceptors from './hook'
 
 export default function Router() {
+    // Axios interceptors for all requests
+    useInterceptors()
+
     return (
         <Routes>
             <Route path="/" element={<Home />} />

--- a/src/redux/reducers/user.js
+++ b/src/redux/reducers/user.js
@@ -20,6 +20,10 @@ const slice = createSlice({
     name: 'user',
     initialState,
     reducers: {
+        cleanUserState(state) {
+            localStorage.removeItem('user');
+            Object.assign(state, initialState);
+        },
         setError(state, {payload: error }){
             state.error = error
         }
@@ -40,8 +44,7 @@ const slice = createSlice({
             })
 
             .addCase(logout.fulfilled, (state) => {
-                localStorage.removeItem('user');
-                Object.assign(state, initialState);
+                slice.caseReducers.cleanUserState(state)
             })
             .addCase(logout.rejected, (state, { payload: error }) => {
                 state.error = error
@@ -63,5 +66,5 @@ const slice = createSlice({
 })
 
 export default slice.reducer
-export const {setError} = slice.actions
+export const {cleanUserState, setError} = slice.actions
 export {login, logout, addUser, updateUser}


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2023-09-18T14:59:22Z" title="Monday, September 18th 2023, 4:59:22 pm +02:00">Sep 18, 2023</time>_
_Merged <time datetime="2023-09-19T07:58:42Z" title="Tuesday, September 19th 2023, 9:58:42 am +02:00">Sep 19, 2023</time>_
---

A 401 error can happen on multiple cases:
- when the session expires and the app is still opened
- when the user log out in a tab but try to use the app on some previously opened tabs
- when the user account has been disabled while using the app
- etc.

These cases are now handled properly, by cleaning the user state and redirecting to the home page, where the login form lives.