### PR TITLE
Administration page link visibility fix

### DIFF
--- a/src/components/Nav/DesktopMenu/index.jsx
+++ b/src/components/Nav/DesktopMenu/index.jsx
@@ -26,11 +26,11 @@ const DesktopMenu = () => {
     
 
     const data = [
-        { text: "Flux d'activité", index: <ForumIcon />, route: `/${organizationId}` },
-        { text: 'Mon profil', index: <PersonIcon/>, route: `/${organizationId}/user/${userId}`},
-        { text: 'Editer mon profil', index: <ManageAccountsIcon/>, route: `/${organizationId}/user/${userId}/edit`},
-        { text: 'Administration', index: <AdminPanelSettingsIcon />, route: `/${organizationId}/admin/members`},
-        { text: 'Contact', index: <ContactMailIcon />, route: "/about" },
+        { text: "Flux d'activité", icon: <ForumIcon />, route: `/${organizationId}` },
+        { text: 'Mon profil', icon: <PersonIcon/>, route: `/${organizationId}/user/${userId}`},
+        { text: 'Editer mon profil', icon: <ManageAccountsIcon/>, route: `/${organizationId}/user/${userId}/edit`},
+        { text: 'Administration', icon: <AdminPanelSettingsIcon />, route: `/${organizationId}/admin/members`},
+        { text: 'Contact', icon: <ContactMailIcon />, route: "/about" },
     
     ]
 
@@ -38,7 +38,7 @@ const DesktopMenu = () => {
        
         <List> 
             <Divider/>
-            {data.map(({ text, index, route }) => (
+            {data.map(({ text, icon, route }) => (
                 <ListItem key={text} 
                     component={Link} 
                     to={route} 
@@ -46,7 +46,7 @@ const DesktopMenu = () => {
                     style={{ textDecoration: 'none', color: 'inherit' }} 
                 >
                     <ListItemButton>
-                        <ListItemIcon>{index}</ListItemIcon>
+                        <ListItemIcon>{icon}</ListItemIcon>
                         <ListItemText primary={text} />
                     </ListItemButton>
                 </ListItem>

--- a/src/components/Nav/DesktopMenu/index.jsx
+++ b/src/components/Nav/DesktopMenu/index.jsx
@@ -1,7 +1,7 @@
 
 import {useDispatch, useSelector } from 'react-redux'
 import { Link, useNavigate } from 'react-router-dom'
-import { getUserId, getUserOrganizationId } from "../../../redux/selectors/user"
+import { getUserId, getIsAdmin, getUserOrganizationId } from "../../../redux/selectors/user"
 import {logout}  from "../../../redux/reducers/user"
 import { Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
@@ -17,6 +17,7 @@ const DesktopMenu = () => {
     const navigate = useNavigate();
     const organizationId = useSelector(getUserOrganizationId);
     const userId = useSelector(getUserId);
+    const isAdmin = useSelector(getIsAdmin);
 
     const handleLogout = async () => {
         await dispatch(logout()).unwrap()
@@ -26,11 +27,11 @@ const DesktopMenu = () => {
     
 
     const data = [
-        { text: "Flux d'activité", icon: <ForumIcon />, route: `/${organizationId}` },
-        { text: 'Mon profil', icon: <PersonIcon/>, route: `/${organizationId}/user/${userId}`},
-        { text: 'Editer mon profil', icon: <ManageAccountsIcon/>, route: `/${organizationId}/user/${userId}/edit`},
-        { text: 'Administration', icon: <AdminPanelSettingsIcon />, route: `/${organizationId}/admin/members`},
-        { text: 'Contact', icon: <ContactMailIcon />, route: "/about" },
+        { text: "Flux d'activité", icon: <ForumIcon />, route: `/${organizationId}`, show: true },
+        { text: 'Mon profil', icon: <PersonIcon/>, route: `/${organizationId}/user/${userId}`, show: true},
+        { text: 'Editer mon profil', icon: <ManageAccountsIcon/>, route: `/${organizationId}/user/${userId}/edit`, show: true},
+        { text: 'Administration', icon: <AdminPanelSettingsIcon />, route: `/${organizationId}/admin/members`, show: isAdmin },
+        { text: 'Contact', icon: <ContactMailIcon />, route: "/about", show: true },
     
     ]
 
@@ -38,19 +39,20 @@ const DesktopMenu = () => {
        
         <List> 
             <Divider/>
-            {data.map(({ text, icon, route }) => (
-                <ListItem key={text} 
-                    component={Link} 
-                    to={route} 
-                    disablePadding    
-                    style={{ textDecoration: 'none', color: 'inherit' }} 
-                >
-                    <ListItemButton>
-                        <ListItemIcon>{icon}</ListItemIcon>
-                        <ListItemText primary={text} />
-                    </ListItemButton>
-                </ListItem>
-            ))}
+            {data.map(({ text, icon, route, show }) =>
+                show &&
+                    <ListItem key={text}
+                        component={Link}
+                        to={route}
+                        disablePadding
+                        style={{ textDecoration: 'none', color: 'inherit' }}
+                    >
+                        <ListItemButton>
+                            <ListItemIcon>{icon}</ListItemIcon>
+                            <ListItemText primary={text} />
+                        </ListItemButton>
+                    </ListItem>
+            )}
             <ListItem key="Déconnexion" 
                 disablePadding 
                 onClick={handleLogout}

--- a/src/components/Nav/MobileMenu/index.jsx
+++ b/src/components/Nav/MobileMenu/index.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
 
 
-import { getIsLogged, getUserId, getUserOrganizationId } from '../../../redux/selectors/user';
+import { getIsLogged, getIsAdmin, getUserId, getUserOrganizationId } from '../../../redux/selectors/user';
 import { logout } from '../../../redux/reducers/user';
 
 
@@ -29,6 +29,7 @@ export default function MobileMenu() {
 
     const organizationId = useSelector(getUserOrganizationId);
     const isLog = useSelector(getIsLogged);
+    const isAdmin = useSelector(getIsAdmin);
     const userId = useSelector(getUserId);
     
 
@@ -95,12 +96,16 @@ export default function MobileMenu() {
                     </ListItemIcon>
                     Editer mon profil
                 </MenuItem>
-                <MenuItem component={Link} to={`/${organizationId}/admin/members`} onClick={handleClose}>
-                    <ListItemIcon>
-                        <AdminPanelSettingsIcon />
-                    </ListItemIcon>
-                    Administration
-                </MenuItem>
+
+                { isAdmin &&
+                    <MenuItem component={Link} to={`/${organizationId}/admin/members`} onClick={handleClose}>
+                        <ListItemIcon>
+                            <AdminPanelSettingsIcon />
+                        </ListItemIcon>
+                        Administration
+                    </MenuItem>
+                }
+
                 <MenuItem component={Link} to="/about" onClick={handleClose}>
                     <ListItemIcon>
                         <ContactMailIcon />

--- a/src/components/Nav/MobileMenu/index.jsx
+++ b/src/components/Nav/MobileMenu/index.jsx
@@ -87,31 +87,31 @@ export default function MobileMenu() {
                     <ListItemIcon>
                         <PersonIcon/>
                     </ListItemIcon>
-                Mon profil
+                    Mon profil
                 </MenuItem>
                 <MenuItem component={Link} to={`/${organizationId}/user/${userId}/edit`} onClick={handleClose}>
                     <ListItemIcon>
                         <ManageAccountsIcon/>
                     </ListItemIcon>
-                Editer mon profil
+                    Editer mon profil
                 </MenuItem>
                 <MenuItem component={Link} to={`/${organizationId}/admin/members`} onClick={handleClose}>
                     <ListItemIcon>
                         <AdminPanelSettingsIcon />
                     </ListItemIcon>
-                Administration
+                    Administration
                 </MenuItem>
                 <MenuItem component={Link} to="/about" onClick={handleClose}>
                     <ListItemIcon>
                         <ContactMailIcon />
                     </ListItemIcon>
-                Contact
+                    Contact
                 </MenuItem>
                 <MenuItem onClick={handleLogout}>
                     <ListItemIcon>
                         <LogoutIcon />
                     </ListItemIcon>
-                Déconnexion
+                    Déconnexion
                 </MenuItem>
             </Menu>
         </>

--- a/src/redux/selectors/user.js
+++ b/src/redux/selectors/user.js
@@ -13,5 +13,6 @@ export const getUserOrganizationName = state => getUserOrganization(state)?.name
 export const getUserId = state => getUser(state).id;
 
 export const getUserRole = state => getUser(state).role;
+export const getIsAdmin = state => !!(getUser(state).role?.tag === 'admin');
 
 export const getUserLoading = state => getUser(state).loading;


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2023-09-27T08:04:32Z" title="Wednesday, September 27th 2023, 10:04:32 am +02:00">Sep 27, 2023</time>_
_Merged <time datetime="2023-09-27T08:32:09Z" title="Wednesday, September 27th 2023, 10:32:09 am +02:00">Sep 27, 2023</time>_
---

Every user was able to see this link in the app menus, whereas the corresponding page can only be accessed by administrators. Now this link is correctly hidden for users who doesn't have access to the "Administration" page.