### PR TITLE
CSRF protection

### DIFF
--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useForm } from "react-hook-form";
 import { useLocation, useNavigate } from "react-router-dom"
 import { useState } from "react";
-import { api } from "../../../services/api";
+import { api, fetchCsrfCookie } from "../../../services/api";
 
 import './style.scss'
 
@@ -72,6 +72,8 @@ function ProfileForm() {
 
     const createOrganization = async () => {
         try {
+            await fetchCsrfCookie()
+
             const { organizationName } = location.state
 
             const { data: organization } = await api.post('/organizations', {

--- a/src/redux/thunks/feed.js
+++ b/src/redux/thunks/feed.js
@@ -71,6 +71,7 @@ export const fetchComments = createAsyncThunk("feed/fetchComments", async (postI
 
 export const addNewComment = createAsyncThunk("feed/addNewComment", async ({text, postId}, thunkApi) => {
     try {
+        await fetchCsrfCookie()
         const { data : newComment } = await api.post(`/posts/${postId}/comments`,  {text: text})
 
         return {newComment, postId}

--- a/src/redux/thunks/feed.js
+++ b/src/redux/thunks/feed.js
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { setAvailablePosts } from '../reducers/feed'
-import { api } from "../../services/api"
+import { api, fetchCsrfCookie } from "../../services/api"
 
 export const fetchPosts = createAsyncThunk("feed/fetchPosts", async (userIdUrl, thunkApi) => {
 
@@ -32,6 +32,8 @@ export const fetchPosts = createAsyncThunk("feed/fetchPosts", async (userIdUrl, 
 
 export const createPost = createAsyncThunk("feed/createPost", async (text, thunkApi) => {
     try {
+        await fetchCsrfCookie()
+
         const { data } = await api.post('/posts',  {text: text})
 
         const newPost = {

--- a/src/redux/thunks/feed.js
+++ b/src/redux/thunks/feed.js
@@ -87,6 +87,7 @@ export const addNewComment = createAsyncThunk("feed/addNewComment", async ({text
 
 export const addReaction = createAsyncThunk("post/addReaction", async ({postId, reaction}, thunkApi) => {
     try {
+        await fetchCsrfCookie()
         const { data : newReaction } = await api.post(`/posts/${postId}/reactions`,  {type: reaction})
 
         return {newReaction, postId}
@@ -104,6 +105,7 @@ export const addReaction = createAsyncThunk("post/addReaction", async ({postId, 
 export const updateReaction = createAsyncThunk("post/updateReaction", async ({postId, reaction, reactionId}, thunkApi) => {
 
     try {
+        await fetchCsrfCookie()
         const { data : updatedReaction } = await api.patch(`/reactions/${reactionId}`,  {type: reaction})
     
         return {updatedReaction, postId, reactionId}
@@ -120,6 +122,7 @@ export const updateReaction = createAsyncThunk("post/updateReaction", async ({po
 export const removeReaction = createAsyncThunk("post/removeReaction", async ({postId, reactionId}, thunkApi) => {
 
     try {
+        await fetchCsrfCookie()
         await api.delete(`/reactions/${reactionId}`,)
         
         return { postId, reactionId}

--- a/src/redux/thunks/members.js
+++ b/src/redux/thunks/members.js
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import { api } from "../../services/api"
+import { api, fetchCsrfCookie } from "../../services/api"
 
 export const fetchMembers = createAsyncThunk("members/fetchMembers", async (organizationId, thunkApi) => {
     try {
@@ -21,6 +21,8 @@ export const fetchMembers = createAsyncThunk("members/fetchMembers", async (orga
 
 export const updateMemberStatus = createAsyncThunk("user/updateMemberStatus", async ({ id, disabled }, thunkAPI) => {
     try {
+        await fetchCsrfCookie()
+
         const response = await api.patch(`/users/${id}`,{disabled: disabled}, )
        
         const updatedMember = response.data

--- a/src/redux/thunks/user.js
+++ b/src/redux/thunks/user.js
@@ -1,9 +1,10 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import { api } from "../../services/api"
+import { api, fetchCsrfCookie } from "../../services/api"
 
 export const login = createAsyncThunk("users/login", async (credentials, thunkApi) => {
 
     try {
+        await fetchCsrfCookie()
         const { data } = await api.post('/session', {email: credentials.email, password: credentials.password} )
 
         const user = data

--- a/src/redux/thunks/user.js
+++ b/src/redux/thunks/user.js
@@ -35,6 +35,7 @@ export const login = createAsyncThunk("users/login", async (credentials, thunkAp
 export const logout = createAsyncThunk("users/logout", async ( thunkApi) => {
 
     try {
+        await fetchCsrfCookie()
         const { data } = await api.delete('/session', )
 
         const user = data

--- a/src/redux/thunks/user.js
+++ b/src/redux/thunks/user.js
@@ -66,6 +66,8 @@ export const logout = createAsyncThunk("users/logout", async ( thunkApi) => {
 
 export const addUser = createAsyncThunk("user/addUser", async (data, thunkAPI) => {
     try {
+        await fetchCsrfCookie()
+
         const formData = new FormData()
         for (let [key,value] of Object.entries(data)) {
             if (key === 'profilePicture' && !value) continue
@@ -87,6 +89,8 @@ export const addUser = createAsyncThunk("user/addUser", async (data, thunkAPI) =
 
 export const updateUser = createAsyncThunk("user/updateUser", async (data, thunkAPI) => {
     try {
+        await fetchCsrfCookie()
+
         const id = thunkAPI.getState().user.id;
         const formData = new FormData()
         for (let [key,value] of Object.entries(data)) {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -2,6 +2,6 @@ import axios from "axios"
 
 
 export const api = axios.create({
-    baseURL: `${import.meta.env.VITE_API_ORIGIN}/api`,
+    baseURL: `${import.meta.env.VITE_API_ORIGIN}`,
     withCredentials: true
 })

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -5,3 +5,11 @@ export const api = axios.create({
     baseURL: `${import.meta.env.VITE_API_ORIGIN}`,
     withCredentials: true
 })
+
+/**
+ * Fetch the CSRF cookie from the API. Must be called before each form
+ * submission.
+ */
+export const fetchCsrfCookie = async () => {
+    await api('/sanctum/csrf-cookie')
+}


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2023-10-04T18:09:33Z" title="Wednesday, October 4th 2023, 8:09:33 pm +02:00">Oct 4, 2023</time>_
_Merged <time datetime="2023-10-05T10:48:41Z" title="Thursday, October 5th 2023, 12:48:41 pm +02:00">Oct 5, 2023</time>_
---

As the CSRF token verification is now enabled server-side, the current one is now fetched before every request to the API which is not a `GET`.
This branch also includes the change in the API base URL (the `/api` prefix has been removed).