### PR TITLE
Fix the inconsistent behavior when a 401 error occurs

### DIFF
--- a/src/components/Router/hook.js
+++ b/src/components/Router/hook.js
@@ -1,12 +1,10 @@
 import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
-import { useNavigate } from 'react-router-dom'
 import { api } from '../../services/api'
 import { cleanUserState } from '../../redux/reducers/user'
 
 export default function useInterceptors() {
     const dispatch = useDispatch()
-    const navigate = useNavigate()
 
     useEffect(() => {
         // The first argument of that use() method is a callback to launch on
@@ -17,10 +15,9 @@ export default function useInterceptors() {
             // tab than the current one, or his/her account has been disabled
             // while using the app... or a lot of possible scenarios, the next
             // request will send back a 401 error. When it happens, we clean the
-            // user state and redirect to the home page.
+            // user state which redirects him/her to the 401 error page.
             if (error.response.status === 401) {
                 dispatch(cleanUserState())
-                navigate('/')
             }
 
             return Promise.reject(error)


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-08-15T10:09:31Z" title="Thursday, August 15th 2024, 12:09:31 pm +02:00">Aug 15, 2024</time>_
_Merged <time datetime="2024-08-15T10:09:49Z" title="Thursday, August 15th 2024, 12:09:49 pm +02:00">Aug 15, 2024</time>_
---

The redirection to the login page when a 401 error occurs was not working very well: if the error occurred when changing page, the 401 error page was appearing briefly before finally displaying the homepage and login form. This flickering was not a really pleasing experience.
When the error occurred after a request which did not involved a navigation, like loading the comments of a post for example, the homepage was not even shown, the user ended on the 401 error page directly.
Removing that redirection to the homepage makes this error handling consistent... and avoids any flickering.