### PR TITLE
Profile form texts tweaks

### DIFF
--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -184,7 +184,20 @@ function ProfileForm() {
             >
                 {isLog ?
                     "Votre profil":
-                    "Créez votre profil"
+                    invitation ? (
+                        <>
+                            Rejoignez <Typography
+                                component="strong"
+                                variant="inherit"
+                                fontStyle="italic"
+                                fontWeight="fontWeightMedium"
+                            >
+                                {invitation.organization.name}
+                            </Typography> sur O'Network
+                        </>
+                    ) : (
+                        "Créez votre profil"
+                    )
                 }
             </Typography>
 

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -165,12 +165,10 @@ function ProfileForm() {
                     width: '100%'
                 },
                 maxWidth: '400px',
-                width: '100%',
                 marginLeft: 'auto',
                 marginRight: 'auto',
                 display: 'flex',
                 flexDirection: 'column',
-                justifyContent: 'center',
                 alignItems: 'center',
                 px:'10px'
             }}
@@ -205,13 +203,7 @@ function ProfileForm() {
                     </Typography>
 
                     <Box className="c-profile-form__body">
-                        <Box
-                            className="c-profile-form__group"
-                            sx={{
-                                display: 'flex',
-                                flexDirection: 'column'
-                            }}
-                        >
+                        <Box className="c-profile-form__group">
                             <Typography
                                 className="c-profile-form__subtitle"
                                 variant="body1"
@@ -298,13 +290,7 @@ function ProfileForm() {
                             )}
                         </Box>
 
-                        <Box
-                            className="c-profile-form__group"
-                            sx={{
-                                display: 'flex',
-                                flexDirection: 'column',
-                            }}
-                        >
+                        <Box className="c-profile-form__group">
                             <Typography
                                 className="c-profile-form__subtitle"
                                 variant="body1"
@@ -353,13 +339,7 @@ function ProfileForm() {
                                 })}
                             />
                         </Box>
-                        <Box
-                            className="c-profile-form__group"
-                            sx={{
-                                display: 'flex',
-                                flexDirection: 'column',
-                            }}
-                        >
+                        <Box className="c-profile-form__group">
                             <Typography
                                 className="c-profile-form__subtitle"
                                 variant="body1"

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -76,13 +76,6 @@ function ProfileForm() {
     const newPassword = watch("newPassword");
     const currentPassword = watch("currentPassword");
 
-    const title = (isLog) => {
-        if (!isLog){
-            return "Bienvenue sur la création de votre profil utilisateur"
-        }
-        return "Bienvenue sur la modification votre profil utilisateur"
-    }
-
     const [deleteUserPicture, setDeleteUserPicture] = useState(false);
 
     const handleDeletePictureChange = (value) => {
@@ -189,7 +182,10 @@ function ProfileForm() {
                 variant="h4"
                 sx={{my:2}}
             >
-                {title(isLog)}
+                {isLog ?
+                    "Bienvenue sur la modification votre profil utilisateur":
+                    "Bienvenue sur la création de votre profil utilisateur"
+                }
             </Typography>
 
             {token && !invitation ?

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -176,253 +176,255 @@ function ProfileForm() {
             }}
             onSubmit={handleSubmit(onSubmit)}
         >
-            <Typography
-                className="c-profile-form__title"
-                component="h1"
-                variant="h4"
-                sx={{my:5}}
-            >
-                {isLog ?
-                    "Votre profil":
-                    invitation ? (
-                        <>
-                            Rejoignez <Typography
-                                component="strong"
-                                variant="inherit"
-                                fontStyle="italic"
-                                fontWeight="fontWeightMedium"
-                            >
-                                {invitation.organization.name}
-                            </Typography> sur O'Network
-                        </>
-                    ) : (
-                        "Créez votre profil"
-                    )
-                }
-            </Typography>
-
             {token && !invitation ?
-                <CircularProgress /> :
-                <Box className="c-profile-form__body">
-                    <Box
-                        className="c-profile-form__group"
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column'
-                        }}
+                <CircularProgress sx={{my: 6}} /> :
+                <>
+                    <Typography
+                        className="c-profile-form__title"
+                        component="h1"
+                        variant="h4"
+                        sx={{my:5}}
                     >
-                        <Typography
-                            className="c-profile-form__subtitle"
-                            variant="body1"
-                            sx={{mb:1}}
-                        >
-                            Votre compte
-                        </Typography>
+                        {isLog ?
+                            "Votre profil":
+                            invitation ? (
+                                <>
+                                    Rejoignez <Typography
+                                        component="strong"
+                                        variant="inherit"
+                                        fontStyle="italic"
+                                        fontWeight="fontWeightMedium"
+                                    >
+                                        {invitation.organization.name}
+                                    </Typography> sur O'Network
+                                </>
+                            ) : (
+                                "Créez votre profil"
+                            )
+                        }
+                    </Typography>
 
-                        {isLog ? (
-                            // {/* ******************************** If is logged ********************************** */}
-                            <>
-                                <TextField
-                                    className="c-profile-form__input"
-                                    label="Ancien mot de passe"
-                                    helperText= {errors.currentPassword?.message}
-                                    error = {!!errors.currentPassword}
-                                    type="password" {...register("currentPassword",{
-                                        required: newPassword ? "L'ancien mot de passe est requis." : null,
-                                        maxLength: {
-                                            value : 64,
-                                            message: "Le mot de passe doit contenir 64 caractères maximum.",
-                                        }
-                                    })}
-                                />
-                                <TextField
-                                    className="c-profile-form__input"
-                                    label="Nouveau mot de passe"
-                                    helperText= {errors.newPassword?.message}
-                                    error = {!!errors.newPassword}
-                                    type="password" {...register("newPassword",{
-                                        required: currentPassword ? "Le nouveau mot de passe est requis." : null,
-                                        pattern: {
-                                            value: /^(?=.*\d)(?=.*[!@#$%^?&*])(?=.*[a-zA-Z]).{8,}$/,
-                                            message: "Le mot de passe doit contenir au moins 8 caractères, une minuscule, une majuscule, un chiffre et un caractère spécial.",
-                                        },
-                                        maxLength: {
-                                            value : 64,
-                                            message: "Le mot de passe doit contenir 64 caractères maximum.",
-                                        }
-                                    })}
-                                />
-                            </>
-                            // {/* ****************************** End if is logged ******************************** */ }
-                        ) : (
-                            // {/* ****************************** If is notLogged ******************************** */}
-                            <>
-                                <TextField
-                                    className="c-profile-form__input"
-                                    label="Email"
-                                    disabled={!!invitation}
-                                    helperText={errors.email?.message}
-                                    error={!!errors.email}
-                                    type="email"{...register("email", {
-                                        required: "L'email est requis",
-                                        pattern: {
-                                            value: /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/,
-                                            message: "L'email doit être valide.",
-                                        },
-                                        maxLength: {
-                                            value: 255,
-                                            message: "L'email doit comporter 255 lettres maximum.",
-                                        }
-                                    })}
-                                />
-                                <TextField
-                                    className="c-profile-form__input"
-                                    label="Mot de passe"
-                                    helperText={errors.password?.message}
-                                    error={!!errors.password}
-                                    type="password" {...register("password", {
-                                        required: "Le mot de passe est requis.",
-                                        pattern: {
-                                            value: /^(?=.*\d)(?=.*[!@#$%^?&*])(?=.*[a-zA-Z]).{8,}$/,
-                                            message: "Le mot de passe doit contenir au moins 8 caractères, une minuscule, une majuscule, un chiffre et un caractère spécial.",
-                                        },
-                                        maxLength: {
-                                            value: 64,
-                                            message: "Le mot de passe doit contenir 64 caractères maximum.",
-                                        }
-                                    })}
-                                />
-                            </>
-                            // {/* **************************** End if is notLogged ****************************** */}
-                        )}
+                    <Box className="c-profile-form__body">
+                        <Box
+                            className="c-profile-form__group"
+                            sx={{
+                                display: 'flex',
+                                flexDirection: 'column'
+                            }}
+                        >
+                            <Typography
+                                className="c-profile-form__subtitle"
+                                variant="body1"
+                                sx={{mb:1}}
+                            >
+                                Votre compte
+                            </Typography>
+
+                            {isLog ? (
+                                // {/* ******************************** If is logged ********************************** */}
+                                <>
+                                    <TextField
+                                        className="c-profile-form__input"
+                                        label="Ancien mot de passe"
+                                        helperText= {errors.currentPassword?.message}
+                                        error = {!!errors.currentPassword}
+                                        type="password" {...register("currentPassword",{
+                                            required: newPassword ? "L'ancien mot de passe est requis." : null,
+                                            maxLength: {
+                                                value : 64,
+                                                message: "Le mot de passe doit contenir 64 caractères maximum.",
+                                            }
+                                        })}
+                                    />
+                                    <TextField
+                                        className="c-profile-form__input"
+                                        label="Nouveau mot de passe"
+                                        helperText= {errors.newPassword?.message}
+                                        error = {!!errors.newPassword}
+                                        type="password" {...register("newPassword",{
+                                            required: currentPassword ? "Le nouveau mot de passe est requis." : null,
+                                            pattern: {
+                                                value: /^(?=.*\d)(?=.*[!@#$%^?&*])(?=.*[a-zA-Z]).{8,}$/,
+                                                message: "Le mot de passe doit contenir au moins 8 caractères, une minuscule, une majuscule, un chiffre et un caractère spécial.",
+                                            },
+                                            maxLength: {
+                                                value : 64,
+                                                message: "Le mot de passe doit contenir 64 caractères maximum.",
+                                            }
+                                        })}
+                                    />
+                                </>
+                                // {/* ****************************** End if is logged ******************************** */ }
+                            ) : (
+                                // {/* ****************************** If is notLogged ******************************** */}
+                                <>
+                                    <TextField
+                                        className="c-profile-form__input"
+                                        label="Email"
+                                        disabled={!!invitation}
+                                        helperText={errors.email?.message}
+                                        error={!!errors.email}
+                                        type="email"{...register("email", {
+                                            required: "L'email est requis",
+                                            pattern: {
+                                                value: /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/,
+                                                message: "L'email doit être valide.",
+                                            },
+                                            maxLength: {
+                                                value: 255,
+                                                message: "L'email doit comporter 255 lettres maximum.",
+                                            }
+                                        })}
+                                    />
+                                    <TextField
+                                        className="c-profile-form__input"
+                                        label="Mot de passe"
+                                        helperText={errors.password?.message}
+                                        error={!!errors.password}
+                                        type="password" {...register("password", {
+                                            required: "Le mot de passe est requis.",
+                                            pattern: {
+                                                value: /^(?=.*\d)(?=.*[!@#$%^?&*])(?=.*[a-zA-Z]).{8,}$/,
+                                                message: "Le mot de passe doit contenir au moins 8 caractères, une minuscule, une majuscule, un chiffre et un caractère spécial.",
+                                            },
+                                            maxLength: {
+                                                value: 64,
+                                                message: "Le mot de passe doit contenir 64 caractères maximum.",
+                                            }
+                                        })}
+                                    />
+                                </>
+                                // {/* **************************** End if is notLogged ****************************** */}
+                            )}
+                        </Box>
+
+                        <Box
+                            className="c-profile-form__group"
+                            sx={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                            }}
+                        >
+                            <Typography
+                                className="c-profile-form__subtitle"
+                                variant="body1"
+                                sx={{mb:1}}
+                            >
+                                Vous
+                            </Typography>
+                            <AvatarForm
+                                className="c-profile-form__avatar"
+                                control={control}
+                                resetField={resetField}
+                                onDeletePictureChange={handleDeletePictureChange}
+                            />
+                            <TextField
+                                className="c-profile-form__input"
+                                label="Nom"
+                                helperText= {errors.surname?.message}
+                                error = {!!errors.surname}
+                                type= "text"{...register("surname", {
+                                    required: "Le nom est requis.",
+                                    minLength: {
+                                        value : 3,
+                                        message: "Le nom doit comporter 3 lettres minimum.",
+                                    },
+                                    maxLength: {
+                                        value : 50,
+                                        message: "Le nom doit contenir 50 caractères maximum.",
+                                    }
+                                })}
+                            />
+                            <TextField
+                                className="c-profile-form__input"
+                                label="Prénom"
+                                helperText= {errors.name?.message}
+                                error = {!!errors.name}
+                                type= "text"{...register("name", {
+                                    required: "Le prénom est requis.",
+                                    minLength: {
+                                        value : 3,
+                                        message: "Le prénom doit comporter 3 lettres minimum.",
+                                    },
+                                    maxLength: {
+                                        value : 50,
+                                        message: "Le prénom doit contenir 50 caractères maximum.",
+                                    }
+                                })}
+                            />
+                        </Box>
+                        <Box
+                            className="c-profile-form__group"
+                            sx={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                            }}
+                        >
+                            <Typography
+                                className="c-profile-form__subtitle"
+                                variant="body1"
+                                sx={{mb:1}}
+                            >
+                                Votre poste
+                            </Typography>
+                            <Typography
+                                className="c-profile-form__textfield"
+                                variant="body1"
+                                sx={{mb:2}}
+                            >
+                                Indiquez ici l'intitulé du poste que vous occupez au sein de l'organisation (p. ex. : graphiste, responsable marketing, etc.)
+                            </Typography>
+                            <TextField
+                                className="c-profile-form__input"
+                                label="Intitulé de poste"
+                                helperText= {errors.job?.message}
+                                error = {!!errors.job}
+                                type= "text"{...register("job", {
+                                    required: "L'intitulé de poste est requis.",
+                                    minLength: {
+                                        value : 3,
+                                        message: "Le titre du poste.",
+                                    },
+                                    maxLength: {
+                                        value : 255,
+                                        message: "Le titre du poste doit contenir 255 caractères maximum.",
+                                    }
+                                })}
+                            />
+                        </Box>
+
+                        {/* This whole block for displaying global error messages is
+                        a bit ugly... but there is no way to simplify it without
+                        refactoring the way server errors are handled in the Redux
+                        thunks. Some explanations:
+                        - with a 422 status code (form validation errors from
+                        Laravel), no global message
+                        - with a 410 status code (invitation expired), the message
+                        is in the server response
+                        - in any other cases, the message is directly in
+                        userError.message (check the Redux thunks to learn more)
+                        */}
+                        {userError !== null && userError?.response?.status !== 422 &&
+                            <p className="c-profile-form__error">{
+                                userError?.response?.status === 410 ?
+                                    userError?.response?.data?.message:
+                                    userError?.message
+                            }</p>
+                        }
+
+                        <Button
+                            className="c-profile-form__button"
+                            sx={{
+                                mt:1,
+                                mb:3
+                            }}
+                            variant="contained"
+                            type="submit"
+                        >
+                            Enregistrer
+                        </Button>
                     </Box>
-
-                    <Box
-                        className="c-profile-form__group"
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                        }}
-                    >
-                        <Typography
-                            className="c-profile-form__subtitle"
-                            variant="body1"
-                            sx={{mb:1}}
-                        >
-                            Vous
-                        </Typography>
-                        <AvatarForm
-                            className="c-profile-form__avatar"
-                            control={control}
-                            resetField={resetField}
-                            onDeletePictureChange={handleDeletePictureChange}
-                        />
-                        <TextField
-                            className="c-profile-form__input"
-                            label="Nom"
-                            helperText= {errors.surname?.message}
-                            error = {!!errors.surname}
-                            type= "text"{...register("surname", {
-                                required: "Le nom est requis.",
-                                minLength: {
-                                    value : 3,
-                                    message: "Le nom doit comporter 3 lettres minimum.",
-                                },
-                                maxLength: {
-                                    value : 50,
-                                    message: "Le nom doit contenir 50 caractères maximum.",
-                                }
-                            })}
-                        />
-                        <TextField
-                            className="c-profile-form__input"
-                            label="Prénom"
-                            helperText= {errors.name?.message}
-                            error = {!!errors.name}
-                            type= "text"{...register("name", {
-                                required: "Le prénom est requis.",
-                                minLength: {
-                                    value : 3,
-                                    message: "Le prénom doit comporter 3 lettres minimum.",
-                                },
-                                maxLength: {
-                                    value : 50,
-                                    message: "Le prénom doit contenir 50 caractères maximum.",
-                                }
-                            })}
-                        />
-                    </Box>
-                    <Box
-                        className="c-profile-form__group"
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                        }}
-                    >
-                        <Typography
-                            className="c-profile-form__subtitle"
-                            variant="body1"
-                            sx={{mb:1}}
-                        >
-                            Votre poste
-                        </Typography>
-                        <Typography
-                            className="c-profile-form__textfield"
-                            variant="body1"
-                            sx={{mb:2}}
-                        >
-                            Indiquez ici l'intitulé du poste que vous occupez au sein de l'organisation (p. ex. : graphiste, responsable marketing, etc.)
-                        </Typography>
-                        <TextField
-                            className="c-profile-form__input"
-                            label="Intitulé de poste"
-                            helperText= {errors.job?.message}
-                            error = {!!errors.job}
-                            type= "text"{...register("job", {
-                                required: "L'intitulé de poste est requis.",
-                                minLength: {
-                                    value : 3,
-                                    message: "Le titre du poste.",
-                                },
-                                maxLength: {
-                                    value : 255,
-                                    message: "Le titre du poste doit contenir 255 caractères maximum.",
-                                }
-                            })}
-                        />
-                    </Box>
-
-                    {/* This whole block for displaying global error messages is
-                    a bit ugly... but there is no way to simplify it without
-                    refactoring the way server errors are handled in the Redux
-                    thunks. Some explanations:
-                    - with a 422 status code (form validation errors from
-                      Laravel), no global message
-                    - with a 410 status code (invitation expired), the message
-                      is in the server response
-                    - in any other cases, the message is directly in
-                      userError.message (check the Redux thunks to learn more)
-                    */}
-                    {userError !== null && userError?.response?.status !== 422 &&
-                        <p className="c-profile-form__error">{
-                            userError?.response?.status === 410 ?
-                                userError?.response?.data?.message:
-                                userError?.message
-                        }</p>
-                    }
-
-                    <Button
-                        className="c-profile-form__button"
-                        sx={{
-                            mt:1,
-                            mb:3
-                        }}
-                        variant="contained"
-                        type="submit"
-                    >
-                        Enregistrer
-                    </Button>
-                </Box>
+                </>
             }
         </Box>
     )

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -209,6 +209,7 @@ function ProfileForm() {
                         <Box className="c-profile-form__group">
                             <Typography
                                 className="c-profile-form__subtitle"
+                                component="h2"
                                 variant="body1"
                                 sx={{mb:1}}
                             >
@@ -296,6 +297,7 @@ function ProfileForm() {
                         <Box className="c-profile-form__group">
                             <Typography
                                 className="c-profile-form__subtitle"
+                                component="h2"
                                 variant="body1"
                                 sx={{mb:1}}
                             >
@@ -345,6 +347,7 @@ function ProfileForm() {
                         <Box className="c-profile-form__group">
                             <Typography
                                 className="c-profile-form__subtitle"
+                                component="h2"
                                 variant="body1"
                                 sx={{mb:1}}
                             >

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -164,13 +164,9 @@ function ProfileForm() {
                     mb: 2,
                     width: '100%'
                 },
-                maxWidth: '400px',
-                marginLeft: 'auto',
-                marginRight: 'auto',
                 display: 'flex',
                 flexDirection: 'column',
                 alignItems: 'center',
-                px:'10px'
             }}
             onSubmit={handleSubmit(onSubmit)}
         >
@@ -181,7 +177,11 @@ function ProfileForm() {
                         className="c-profile-form__title"
                         component="h1"
                         variant="h4"
-                        sx={{my:5}}
+                        sx={{
+                            maxWidth: '600px',
+                            my: 5,
+                            px: 3
+                        }}
                     >
                         {isLog ?
                             "Votre profil":
@@ -202,7 +202,10 @@ function ProfileForm() {
                         }
                     </Typography>
 
-                    <Box className="c-profile-form__body">
+                    <Box className="c-profile-form__body" sx={{
+                        maxWidth: '400px',
+                        px: '10px'
+                    }}>
                         <Box className="c-profile-form__group">
                             <Typography
                                 className="c-profile-form__subtitle"

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -180,11 +180,11 @@ function ProfileForm() {
                 className="c-profile-form__title"
                 component="h1"
                 variant="h4"
-                sx={{my:2}}
+                sx={{my:5}}
             >
                 {isLog ?
-                    "Bienvenue sur la modification votre profil utilisateur":
-                    "Bienvenue sur la création de votre profil utilisateur"
+                    "Votre profil":
+                    "Créez votre profil"
                 }
             </Typography>
 

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -1,5 +1,6 @@
 import AvatarForm from "../AvatarForm";
 import { Box, Button, CircularProgress, TextField, Typography } from '@mui/material';
+import { grey } from "@mui/material/colors";
 import { addUser, updateUser } from '../../../redux/reducers/user'
 import { getUser, getIsLogged, getUserError } from '../../../redux/selectors/user'
 import { useDispatch, useSelector } from 'react-redux';
@@ -355,8 +356,13 @@ function ProfileForm() {
                             </Typography>
                             <Typography
                                 className="c-profile-form__textfield"
-                                variant="body1"
-                                sx={{mb:2}}
+                                variant="body2"
+                                sx={{
+                                    mb:2,
+                                    fontStyle: "italic",
+                                    color: grey[600],
+                                    maxWidth: "350px"
+                                }}
                             >
                                 Indiquez ici l'intitulé du poste que vous occupez au sein de l'organisation (p. ex. : graphiste, responsable marketing, etc.)
                             </Typography>

--- a/src/components/Forms/ProfileForm/style.scss
+++ b/src/components/Forms/ProfileForm/style.scss
@@ -9,12 +9,10 @@
     }
 
     &__subtitle {
-        margin-bottom: 1;
     }
 
     &__textfield {
         margin-top: 0;
-        margin-bottom: 1;
     }
 
     &__error {

--- a/src/components/Forms/ProfileForm/style.scss
+++ b/src/components/Forms/ProfileForm/style.scss
@@ -1,6 +1,7 @@
 .c-profile-form {
     &__group {
         width: 100%;
+        margin-bottom: 40px;
     }
 
     &__title {
@@ -9,6 +10,11 @@
     }
 
     &__subtitle {
+        font-size: 21px !important;
+    }
+
+    &__input:last-child {
+        margin-bottom: 0 !important;
     }
 
     &__textfield {

--- a/src/components/Nav/DesktopMenu/index.jsx
+++ b/src/components/Nav/DesktopMenu/index.jsx
@@ -28,7 +28,6 @@ const DesktopMenu = () => {
 
     const data = [
         { text: "Flux d'activité", icon: <ForumIcon />, route: `/${organizationId}`, show: true },
-        { text: 'Mon profil', icon: <PersonIcon/>, route: `/${organizationId}/user/${userId}`, show: true},
         { text: 'Editer mon profil', icon: <ManageAccountsIcon/>, route: `/${organizationId}/user/${userId}/edit`, show: true},
         { text: 'Administration', icon: <AdminPanelSettingsIcon />, route: `/${organizationId}/admin/members`, show: isAdmin },
         { text: 'Contact', icon: <ContactMailIcon />, route: "/about", show: true },

--- a/src/components/Nav/MobileMenu/index.jsx
+++ b/src/components/Nav/MobileMenu/index.jsx
@@ -84,12 +84,6 @@ export default function MobileMenu() {
                     </ListItemIcon>
                     {'Flux d\'activité'}
                 </MenuItem>
-                <MenuItem component={Link} to={`/${organizationId}/user/${userId}`} onClick={handleClose}>
-                    <ListItemIcon>
-                        <PersonIcon/>
-                    </ListItemIcon>
-                    Mon profil
-                </MenuItem>
                 <MenuItem component={Link} to={`/${organizationId}/user/${userId}/edit`} onClick={handleClose}>
                     <ListItemIcon>
                         <ManageAccountsIcon/>


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-10-09T20:55:07Z" title="Wednesday, October 9th 2024, 10:55:07 pm +02:00">Oct 9, 2024</time>_
_Merged <time datetime="2024-10-09T20:57:34Z" title="Wednesday, October 9th 2024, 10:57:34 pm +02:00">Oct 9, 2024</time>_
---

The titles of the profile form needed some refinement.

The main ones were too long and felt overly "welcoming" to sound natural. They are now simpler and shorter. And in the case of an invitation, the title includes the name of the organization, highlighted in italic and semi-bold text.

But while those changes were not originally planned, some details from the mockups had not been included. The subtitles and the description of the job field were not the same size as the standard text in the mockups. Additionally, the description was supposed to be italic, gray and not full-width. All of these aspects have been fixed to better match the mockups, and the overall result is more visually appealing.

A few things have also been modified on a more technical level. Check the commit messages to learn more.