### PR TITLE
Modifications of the user profile not kept after page reload

### DIFF
--- a/src/redux/reducers/user.js
+++ b/src/redux/reducers/user.js
@@ -57,6 +57,7 @@ const slice = createSlice({
                 state.error = error
             })
             .addCase(updateUser.fulfilled,(state, {payload: data}) => {
+                localStorage.setItem('user', JSON.stringify(data))
                 return {...state, ...data, error: null}
             })
             .addCase(updateUser.rejected, (state, {payload: error}) => {


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-10-10T17:46:11Z" title="Thursday, October 10th 2024, 7:46:11 pm +02:00">Oct 10, 2024</time>_
_Merged <time datetime="2024-10-10T17:46:21Z" title="Thursday, October 10th 2024, 7:46:21 pm +02:00">Oct 10, 2024</time>_
---

After using the form to update the user's profile and reloading the page (or just closing the tab or the browser), the modifications were lost on the client side. The current user is stored in localStorage to persist their data between page reloads, and this entry was simply not updated after submitting the form.

Using localStorage for this purpose is far from ideal, and this behavior will be changed in future commits. However, this quick fix eliminates that annoying bug!