### PR TITLE
Fix the buggy comment counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-react-refresh": "^0.4.1",
     "moment": "^2.29.4",
     "react-hook-form": "^7.45.1",
+    "react-pluralize": "^1.6.3",
     "react-redux": "^8.1.1",
     "react-router-dom": "^6.14.1",
     "react-router-hash-link": "^2.4.3",

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -19,6 +19,7 @@ import {Avatar, Collapse, List, Box} from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { Link as MuiLink } from '@mui/material'
 import { HashLink } from 'react-router-hash-link';
+import Pluralize from 'react-pluralize'
 
 import './style.scss'
 
@@ -117,7 +118,7 @@ function Post({id, author,text,commentsCount,createdAt}) {
                     aria-label="show more"
                     className='c-counter__btn' 
                 >
-                    {commentsCount}{" commentaires"}
+                    <Pluralize count={commentsCount} singular="commentaire" />
                 </ExpandMore>
             </CardContent>
             <Divider/>

--- a/src/redux/reducers/feed.js
+++ b/src/redux/reducers/feed.js
@@ -95,7 +95,9 @@ const slice = createSlice({
             
 
             .addCase(addNewComment.fulfilled, (state, { payload: { postId, newComment } } ) => {
-                state.posts.find(post => post.id === postId).comments.push(newComment)
+                const post = state.posts.find(post => post.id === postId)
+                post.comments.push(newComment)
+                post.commentsCount++
             })
 
             .addCase(addNewComment.rejected, (state,action) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,6 +2085,11 @@ react-is@^18.0.0, react-is@^18.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-pluralize@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/react-pluralize/-/react-pluralize-1.6.3.tgz#8d7dba3c584001f8c540717d6ba1601fa264a561"
+  integrity sha512-TOpCsnMNTpMgEJFsxdwsHHxvChvrWKENsYkK9At5B+0CZTEc40CAMqvXKnz8C3VDt0LBL8491kEnL61IH3CUHA==
+
 react-redux@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.1.1.tgz#8e740f3fd864a4cd0de5ba9cdc8ad39cc9e7c81a"


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-10-29T17:16:53Z" title="Tuesday, October 29th 2024, 6:16:53 pm +01:00">Oct 29, 2024</time>_
_Merged <time datetime="2024-10-29T17:17:11Z" title="Tuesday, October 29th 2024, 6:17:11 pm +01:00">Oct 29, 2024</time>_
---

The comments counter of a post wasn't incrementing after publishing a new comment.
This counter isn't based on the current `post.comments` state, as comments are loaded only on demand. While this array was correctly updated, the cached count was not.

Additionally, the counter was always using the plural form, even when there was only one comment. It has been fixed with the help of the react-pluralize package.