### PR TITLE
Server errors of organization form attached to field

### DIFF
--- a/src/components/Forms/OrganizationForm/index.jsx
+++ b/src/components/Forms/OrganizationForm/index.jsx
@@ -63,7 +63,6 @@ function OrganizationForm() {
             
             <form className="c-organization-form__form" onSubmit={handleSubmit(onSubmit)}>
                 <TextField 
-                    name="organization"
                     type="text"
                     label="Nom de votre organisation"
                     helperText= {errors.organizationName?.message}

--- a/src/components/Forms/OrganizationForm/index.jsx
+++ b/src/components/Forms/OrganizationForm/index.jsx
@@ -13,19 +13,16 @@ function OrganizationForm() {
 
     const { register, handleSubmit, formState: { errors } } = useForm()
     const navigate = useNavigate();
-    const [organizationName, setOrganizationName] = useState(null)
+    const [name, setName] = useState(null)
     const [isLoading, setIsLoading] = useState(false)
     const [globalFormError, setGlobalFormError] = useState(null)
 
-    const onSubmit = async ({ organizationName }) => {
+    const onSubmit = async ({ name }) => {
         setIsLoading(true)
 
         try {
-            await api('/organizations/validation', { params: {
-                name: organizationName
-            }})
-
-            setOrganizationName(organizationName)
+            await api('/organizations/validation', { params: { name }})
+            setName(name)
         }
         catch (error) {
             handleError(error)
@@ -51,10 +48,10 @@ function OrganizationForm() {
     }
 
     useEffect(() => {
-        if (organizationName) {
-            navigate('/sign-up', { state: { organizationName } });
+        if (name) {
+            navigate('/sign-up', { state: { organizationName: name } });
         }
-    }, [organizationName, navigate]);
+    }, [name, navigate]);
 
     return (
         <div className="c-organization-form">
@@ -65,9 +62,9 @@ function OrganizationForm() {
                 <TextField 
                     type="text"
                     label="Nom de votre organisation"
-                    helperText= {errors.organizationName?.message}
-                    error = {!!errors.organizationName}
-                    {...register('organizationName',{
+                    helperText= {errors.name?.message}
+                    error = {!!errors.name}
+                    {...register('name',{
                         required:"Le nom de l'organisation est requis",
                         minLength: {
                             value : 3,

--- a/src/components/Forms/OrganizationForm/index.jsx
+++ b/src/components/Forms/OrganizationForm/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { TextField, Button, CircularProgress } from '@mui/material'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from "react-router-dom"
@@ -13,7 +13,6 @@ function OrganizationForm() {
 
     const { register, handleSubmit, formState: { errors } } = useForm()
     const navigate = useNavigate();
-    const [name, setName] = useState(null)
     const [isLoading, setIsLoading] = useState(false)
     const [globalFormError, setGlobalFormError] = useState(null)
 
@@ -22,7 +21,7 @@ function OrganizationForm() {
 
         try {
             await api('/organizations/validation', { params: { name }})
-            setName(name)
+            navigate('/sign-up', { state: { organizationName: name } });
         }
         catch (error) {
             handleError(error)
@@ -46,12 +45,6 @@ function OrganizationForm() {
             });
         }
     }
-
-    useEffect(() => {
-        if (name) {
-            navigate('/sign-up', { state: { organizationName: name } });
-        }
-    }, [name, navigate]);
 
     return (
         <div className="c-organization-form">

--- a/src/components/Forms/OrganizationForm/index.jsx
+++ b/src/components/Forms/OrganizationForm/index.jsx
@@ -48,7 +48,7 @@ function OrganizationForm() {
             <p className="c-organization-form__text">Merci de bien vouloir renseigner le nom de votre organisation et cliquer sur le bouton de validation pour continuer.</p>
             
             <form className="c-organization-form__form" onSubmit={handleSubmit(onSubmit)}>
-                <TextField 
+                <TextField fullWidth
                     type="text"
                     label="Nom de votre organisation"
                     helperText= {errors.name?.message}

--- a/src/components/Forms/OrganizationForm/index.jsx
+++ b/src/components/Forms/OrganizationForm/index.jsx
@@ -15,7 +15,7 @@ function OrganizationForm() {
     const navigate = useNavigate();
     const [organizationName, setOrganizationName] = useState(null)
     const [isLoading, setIsLoading] = useState(false)
-    const [error, setError] = useState(null)
+    const [globalFormError, setGlobalFormError] = useState(null)
 
     const onSubmit = async ({ organizationName }) => {
         setIsLoading(true)
@@ -37,13 +37,13 @@ function OrganizationForm() {
 
     const handleError = error => {
         if (error.response.status === 409) {
-            setError({
+            setGlobalFormError({
                 status: 409,
                 message: 'Cette organisation existe déjà. Merci de choisir un autre nom.'
             });
         }
         else {
-            setError({
+            setGlobalFormError({
                 status: error.response.status,
                 message: "Une erreur s'est produite lors de la création de l'organisation."
             });
@@ -82,8 +82,8 @@ function OrganizationForm() {
                 />
                 {isLoading ? <CircularProgress/> : null}
 
-                {error !== null && (
-                    <p className="c-organization-form__error">{error.message}</p>
+                {globalFormError !== null && (
+                    <p className="c-organization-form__error">{globalFormError.message}</p>
                 )}
 
                 <Button sx={{ m:1,}} className="c-organization-form__button" variant="contained" type="submit" >Valider</Button>

--- a/src/components/Forms/OrganizationForm/style.scss
+++ b/src/components/Forms/OrganizationForm/style.scss
@@ -1,10 +1,11 @@
 
 
 .c-organization-form{
-   
+    max-width: 500px;
     justify-content: center;
     align-items: center;
-    padding:10%;
+    padding: 0 10px;
+    margin: 80px auto 0 auto;
 
     &__text{
        justify-content: center;


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-11-08T16:50:41Z" title="Friday, November 8th 2024, 5:50:41 pm +01:00">Nov 8, 2024</time>_
_Merged <time datetime="2024-11-08T17:07:38Z" title="Friday, November 8th 2024, 6:07:38 pm +01:00">Nov 8, 2024</time>_
---

All the forms in the app (profile form and invitation form) display their server errors below the corresponding fields, thanks to the `setFieldsServerErrors()` function of the custom `useServerErrors` hook. But it was not the case yet for the organization form, which is now corrected.

Additionally the code of the `OrganizationForm` component has been simplified: 
- a `useEffect()` which was not necessary anymore has been removed
- the field name is now just "name" like in database, avoiding variable names conversions

To properly display the server error messages under the organization name field (in the `helperText` property of the MUI's `<TextField>` component), the input has been expanded to take the full width of the entire form container. The form itself has also been stretched to a max-width to keep a clean appearance.