### PR TITLE
Error pages without URL rewriting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,7 +12,7 @@ module.exports = {
     settings: { react: { version: '18.2' } },
     plugins: ['react-refresh'],
     rules: {
-        indent: ['warn', 4],
+        indent: ['warn', 4, { "SwitchCase": 1 }],
         'react-refresh/only-export-components': [
             'warn',
             { allowConstantExport: true },

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -3,12 +3,12 @@ import { useDispatch } from 'react-redux'
 import { fetchUser } from '../../redux/thunks/user'
 import Router from '../Router'
 import LoadingLayout from '../../layout/LoadingLayout'
-import Error500 from '../../views/Error500'
+import ErrorPageHandler from '../Router/ErrorPageHandler'
+import { ERROR_CODE, setErrorPage } from '../../redux/reducers/errorPage'
 
 function App() {
     const dispatch = useDispatch()
     const [isFetchingUser, setIsFetchingUser] = useState(true)
-    const [userFetchingError, setUserFetchingError] = useState(null)
 
     useEffect(() => {
         (async () => {
@@ -16,7 +16,7 @@ function App() {
                 await dispatch(fetchUser()).unwrap()
             }
             catch (error) {
-                setUserFetchingError(error)
+                dispatch(setErrorPage(ERROR_CODE[500]))
             }
             finally {
                 setIsFetchingUser(false)
@@ -25,11 +25,11 @@ function App() {
     }, [dispatch])
 
     return (
-        userFetchingError ?
-            <Error500 /> :
-            isFetchingUser ?
-                <LoadingLayout/> :
+        isFetchingUser ?
+            <LoadingLayout/> :
+            <ErrorPageHandler>
                 <Router/>
+            </ErrorPageHandler>
     )
 }
 

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -9,6 +9,7 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom"
 import { useEffect, useState } from "react";
 import { api, fetchCsrfCookie } from "../../../services/api";
 import useServerErrors from "../useServerErrors";
+import { ERROR_CODE, setErrorPage } from "../../../redux/reducers/errorPage";
 
 import './style.scss'
 
@@ -50,7 +51,7 @@ function ProfileForm() {
         if (token === null) return
 
         if (!token.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/)) {
-            navigate('/error/404')
+            dispatch(setErrorPage(ERROR_CODE[404]))
             return
         }
 
@@ -62,10 +63,10 @@ function ProfileForm() {
             }
             catch (error) {
                 if (error.response.status === 404) {
-                    navigate('/error/404')
+                    dispatch(setErrorPage(ERROR_CODE[404]))
                 }
                 else {
-                    navigate('/error/500')
+                    dispatch(setErrorPage(ERROR_CODE[500]))
                 }
             }
         }

--- a/src/components/Nav/ButtonHome/index.jsx
+++ b/src/components/Nav/ButtonHome/index.jsx
@@ -6,12 +6,15 @@ import BasicButton from '../../Buttons/BasicButton';
 import Button from '@mui/material/Button';
 import { Box } from '@mui/material';
 import { HashLink } from 'react-router-hash-link';
+import { getErrorPageCode } from '../../../redux/selectors/errorPage';
+import { ERROR_CODE } from '../../../redux/reducers/errorPage';
 
 import './style.scss';
 
 export default function ButtonHome() {
     const location = useLocation();
     const isLog = useSelector(getIsLogged);
+    const errorCode = useSelector(getErrorPageCode)
     const currentPath = location.pathname;
     const organizationId = useSelector(getUserOrganizationId);
     const userId = useSelector(getUserId);
@@ -22,9 +25,7 @@ export default function ButtonHome() {
             {isLog &&
                 (currentPath === '/about' ||
                 currentPath === `/${organizationId}/user/${userId}/edit` ||
-                currentPath === '/error/403' ||
-                currentPath === '/error/404' ||
-                currentPath === '/error/500') && (
+                [ERROR_CODE[403], ERROR_CODE[404], ERROR_CODE[500]].includes(errorCode)) && (
                 <BasicButton
                     sx={{ display: { xs: 'none', sm: 'block' } }}
                     className="c-button-header_btn"
@@ -52,9 +53,7 @@ export default function ButtonHome() {
                 (currentPath === '/sign-up' ||
                 currentPath === '/new-organization' ||
                 currentPath === '/about' ||
-                currentPath === '/error/401' ||
-                currentPath === '/error/404' ||
-                currentPath === '/error/500') && (
+                [ERROR_CODE[401], ERROR_CODE[404], ERROR_CODE[500]].includes(errorCode)) && (
                 <Button
                     className="c-button-header_btn"
                     variant="outlined"

--- a/src/components/Router/AdminRoute/index.jsx
+++ b/src/components/Router/AdminRoute/index.jsx
@@ -1,15 +1,24 @@
+import { useEffect } from 'react';
 import PropTypes from 'prop-types'
-import { Navigate } from 'react-router-dom'
-import { useSelector } from 'react-redux'
-import { getUserRole } from '../../../redux/selectors/user';
+import { useDispatch, useSelector } from 'react-redux'
+import { getIsAdmin } from '../../../redux/selectors/user';
+import { ERROR_CODE, setErrorPage } from '../../../redux/reducers/errorPage';
 
 export default function AdminRoute({ children }) {
-    const userRole = useSelector(getUserRole);
+    const dispatch = useDispatch()
+    const isAdmin = useSelector(getIsAdmin);
 
-    if (userRole.tag !== "admin"){
-        return <Navigate to="/error/403" replace/>
-    }
-    return children
+    // A useEffect is required here to dispatch the action AFTER the rendering
+    // of the component, because the ErrorPageHandler component can interrupt
+    // the rendering of every other one inside it once an error is set. Such an
+    // interruption can lead to strange behaviors and fire an error in console.
+    useEffect(() => {
+        if (!isAdmin) {
+            dispatch(setErrorPage(ERROR_CODE[403]))
+        }
+    })
+
+    return isAdmin && children
 }
 
 AdminRoute.propTypes = {

--- a/src/components/Router/ErrorPageHandler/index.jsx
+++ b/src/components/Router/ErrorPageHandler/index.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import { useDispatch, useSelector } from "react-redux"
+import { useLocation } from 'react-router-dom'
+import { getErrorPageCode } from "../../../redux/selectors/errorPage"
+import Error401 from "../../../views/Error401"
+import Error403 from "../../../views/Error403"
+import Error404 from "../../../views/Error404"
+import Error500 from "../../../views/Error500"
+import { setErrorPage } from '../../../redux/reducers/errorPage'
+
+function ErrorPageHandler({ children }) {
+    const dispatch = useDispatch()
+    const { pathname } = useLocation()
+    const [previousPathname, setPreviousPathname] = useState(pathname)
+    const code = useSelector(getErrorPageCode)
+
+    // A useEffect is required here to dispatch the action AFTER the rendering
+    // of the component, because it can interrupt its own rendering once an
+    // error is set. Such an interruption can lead to strange behaviors and fire
+    // an error in console.
+    useEffect(() => {
+        if (pathname !== previousPathname) {
+            if (code) dispatch(setErrorPage(null))
+            setPreviousPathname(pathname)
+        }
+    }, [dispatch, pathname, previousPathname, code])
+
+    switch (code) {
+        case 401:
+            return <Error401 />
+        case 403:
+            return <Error403 />
+        case 404:
+            return <Error404 />
+        case 500:
+            return <Error500 />
+        default:
+            return children
+    }
+}
+
+ErrorPageHandler.propTypes = {
+    children: PropTypes.node.isRequired
+}
+
+export default ErrorPageHandler

--- a/src/components/Router/GuestRoute/index.jsx
+++ b/src/components/Router/GuestRoute/index.jsx
@@ -1,16 +1,24 @@
 import PropTypes from 'prop-types'
-import { useSelector } from 'react-redux'
-import { Navigate } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
 import { getIsLogged } from '../../../redux/selectors/user'
+import { ERROR_CODE, setErrorPage } from '../../../redux/reducers/errorPage'
+import { useEffect } from 'react'
 
 export default function GuestRoute({ children }) {
+    const dispatch = useDispatch()
     const isLog = useSelector(getIsLogged)
 
-    if (isLog) {
-        return <Navigate to="/error/403" replace />
-    }
+    // A useEffect is required here to dispatch the action AFTER the rendering
+    // of the component, because the ErrorPageHandler component can interrupt
+    // the rendering of every other one inside it once an error is set. Such an
+    // interruption can lead to strange behaviors and fire an error in console.
+    useEffect(() => {
+        if (isLog) {
+            dispatch(setErrorPage(ERROR_CODE[403]))
+        }
+    })
 
-    return children
+    return !isLog && children
 }
 
 GuestRoute.propTypes = {

--- a/src/components/Router/ProtectedRoute/index.jsx
+++ b/src/components/Router/ProtectedRoute/index.jsx
@@ -1,22 +1,34 @@
 import PropTypes from 'prop-types'
-import { Navigate, useParams } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useParams } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
 import { getIsLogged } from '../../../redux/selectors/user';
+import { ERROR_CODE, setErrorPage } from '../../../redux/reducers/errorPage';
+import { useEffect } from 'react';
 
 export default function ProtectedRoute({ children }) {
+    const dispatch = useDispatch()
     const isLog = useSelector(getIsLogged);
     const { organizationId } = useParams();
     const organizationIdIsValid = Number.isInteger(parseInt(organizationId))
+    const hasError = !organizationIdIsValid || !isLog
 
+    // A useEffect is required here to dispatch the action AFTER the rendering
+    // of the component, because the ErrorPageHandler component can interrupt
+    // the rendering of every other one inside it once an error is set. Such an
+    // interruption can lead to strange behaviors and fire an error in console.
+    useEffect(() => {
+        if (!organizationIdIsValid) {
+            dispatch(setErrorPage(ERROR_CODE[404]))
+            return
+        }
 
-    if (!organizationIdIsValid) {
-        return <Navigate to="/error/404" replace />
-    }
-    if (!isLog) {
-        return <Navigate to="/error/401" replace />
-    }
+        if (!isLog) {
+            dispatch(setErrorPage(ERROR_CODE[401]))
+            return
+        }
+    })
 
-    return children
+    return !hasError && children
 }
 
 ProtectedRoute.propTypes = {

--- a/src/components/Router/index.jsx
+++ b/src/components/Router/index.jsx
@@ -10,10 +10,7 @@ import ProfileSettings from '../../views/ProfileSettings'
 import Contact from '../../views/Contact'
 import SignUp from '../../views/SignUp'
 import ActivityFeed from '../../views/ActivityFeed'
-import Error401 from '../../views/Error401'
-import Error403 from '../../views/Error403'
 import Error404 from '../../views/Error404'
-import Error500 from '../../views/Error500'
 import useInterceptors from './hook'
 
 export default function Router() {
@@ -34,10 +31,6 @@ export default function Router() {
                 </GuestRoute>
             } />
             <Route path="/about" element={<Contact />} />
-            <Route path="/error/401" element={<Error401 />} />
-            <Route path="/error/403" element={<Error403 />} />
-            <Route path="/error/404" element={<Error404 />} />
-            <Route path="/error/500" element={<Error500 />} />
             <Route
                 path={`/:organizationId`}
                 element={

--- a/src/redux/reducers/errorPage.js
+++ b/src/redux/reducers/errorPage.js
@@ -1,0 +1,26 @@
+import { createSlice } from "@reduxjs/toolkit"
+
+const ERROR_CODE = {
+    401: 401,
+    403: 403,
+    404: 404,
+    500: 500,
+}
+
+const initialState = {
+    code: null
+}
+
+const slice = createSlice({
+    name: 'errorPage',
+    initialState,
+    reducers: {
+        setErrorPage(state, { payload: code }) {
+            state.code = code
+        }
+    }
+})
+
+export { ERROR_CODE }
+export const { setErrorPage } = slice.actions
+export default slice.reducer

--- a/src/redux/selectors/errorPage.js
+++ b/src/redux/selectors/errorPage.js
@@ -1,0 +1,1 @@
+export const getErrorPageCode = state => state.errorPage.code

--- a/src/redux/store/index.js
+++ b/src/redux/store/index.js
@@ -1,5 +1,6 @@
 import { configureStore } from "@reduxjs/toolkit";
 import user from "../reducers/user";
+import errorPage from "../reducers/errorPage"
 import feed from "../reducers/feed";
 import members from "../reducers/members";
 
@@ -7,6 +8,7 @@ import members from "../reducers/members";
 
 const reducer = {
     user,
+    errorPage,
     feed,
     members
 }


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-11-13T10:46:34Z" title="Wednesday, November 13th 2024, 11:46:34 am +01:00">Nov 13, 2024</time>_
_Merged <time datetime="2024-11-13T10:46:47Z" title="Wednesday, November 13th 2024, 11:46:47 am +01:00">Nov 13, 2024</time>_
---

When an error occurs, the app displays an error page to the user (among 401, 403, 404 and 500). But until now, the user was redirected to one of these pages, which rewrote the URL. However, users should always be able to see the original URL that caused the error, so these redirects didn't provide an ideal experience.

Now, a new `ErrorPageHandler` component wraps the `Router`, and can be controlled through Redux to display either an error page or the intended component. All error pages of the app are now displayed through this system, so the URL is never rewritten.

Additionally, a new setting has been added to the ESLint config, as it triggered a warning about the indentation of switch/case blocks.