### PR TITLE
Missing back button on router 404 error

### DIFF
--- a/src/components/Router/NotFoundRoute/index.jsx
+++ b/src/components/Router/NotFoundRoute/index.jsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react"
+import { useDispatch } from "react-redux"
+import { ERROR_CODE, setErrorPage } from "../../../redux/reducers/errorPage"
+
+function NotFoundRoute() {
+    const dispatch = useDispatch()
+
+    // A useEffect is required here to dispatch the action AFTER the rendering
+    // of the component, because the ErrorPageHandler component can interrupt
+    // the rendering of every other one inside it once an error is set. Such an
+    // interruption can lead to strange behaviors and fire an error in console.
+    useEffect(() => {
+        dispatch(setErrorPage(ERROR_CODE[404]))
+    })
+
+    return null
+}
+
+export default NotFoundRoute

--- a/src/components/Router/index.jsx
+++ b/src/components/Router/index.jsx
@@ -66,10 +66,7 @@ export default function Router() {
                     </ProtectedRoute>
                 }
             />
-            <Route
-                path="/*"
-                element={<NotFoundRoute />}
-            />
+            <Route path="/*" element={<NotFoundRoute />} />
         </Routes>
     )
 }

--- a/src/components/Router/index.jsx
+++ b/src/components/Router/index.jsx
@@ -10,7 +10,7 @@ import ProfileSettings from '../../views/ProfileSettings'
 import Contact from '../../views/Contact'
 import SignUp from '../../views/SignUp'
 import ActivityFeed from '../../views/ActivityFeed'
-import Error404 from '../../views/Error404'
+import NotFoundRoute from './NotFoundRoute'
 import useInterceptors from './hook'
 
 export default function Router() {
@@ -68,7 +68,7 @@ export default function Router() {
             />
             <Route
                 path="/*"
-                element={<Error404 />}
+                element={<NotFoundRoute />}
             />
         </Routes>
     )


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-11-13T15:21:13Z" title="Wednesday, November 13th 2024, 4:21:13 pm +01:00">Nov 13, 2024</time>_
_Merged <time datetime="2024-11-13T15:21:34Z" title="Wednesday, November 13th 2024, 4:21:34 pm +01:00">Nov 13, 2024</time>_
---

Since the previous PR, all error pages are displayed through the `ErrorPageHandler` component. 

However, one part of the app was overlooked: the router 404 error, triggered by the wilcard path (`/*`). So when a URL that didn't match any configured route was requested, the 404 error page was displayed correctly but the back button from the `ButtonHome` component was missing.

To resolve this, the cleanest solution was to handle this error with the `ErrorPageHandler`, which required creating a new component, `NotFoundRoute`, to integrate with React Router.