### PR TITLE
Error code enum refactoring

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -4,7 +4,7 @@ import { fetchUser } from '../../redux/thunks/user'
 import Router from '../Router'
 import LoadingLayout from '../../layout/LoadingLayout'
 import ErrorPageHandler from '../Router/ErrorPageHandler'
-import { ERROR_CODE, setErrorPage } from '../../redux/reducers/errorPage'
+import { ErrorCode, setErrorPage } from '../../redux/reducers/errorPage'
 
 function App() {
     const dispatch = useDispatch()
@@ -16,7 +16,7 @@ function App() {
                 await dispatch(fetchUser()).unwrap()
             }
             catch (error) {
-                dispatch(setErrorPage(ERROR_CODE[500]))
+                dispatch(setErrorPage(ErrorCode[500]))
             }
             finally {
                 setIsFetchingUser(false)

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -16,7 +16,7 @@ function App() {
                 await dispatch(fetchUser()).unwrap()
             }
             catch (error) {
-                dispatch(setErrorPage(ErrorCode[500]))
+                dispatch(setErrorPage(ErrorCode.INTERNAL_SERVER_ERROR))
             }
             finally {
                 setIsFetchingUser(false)

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -9,7 +9,7 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom"
 import { useEffect, useState } from "react";
 import { api, fetchCsrfCookie } from "../../../services/api";
 import useServerErrors from "../useServerErrors";
-import { ERROR_CODE, setErrorPage } from "../../../redux/reducers/errorPage";
+import { ErrorCode, setErrorPage } from "../../../redux/reducers/errorPage";
 
 import './style.scss'
 
@@ -51,7 +51,7 @@ function ProfileForm() {
         if (token === null) return
 
         if (!token.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/)) {
-            dispatch(setErrorPage(ERROR_CODE[404]))
+            dispatch(setErrorPage(ErrorCode[404]))
             return
         }
 
@@ -63,10 +63,10 @@ function ProfileForm() {
             }
             catch (error) {
                 if (error.response.status === 404) {
-                    dispatch(setErrorPage(ERROR_CODE[404]))
+                    dispatch(setErrorPage(ErrorCode[404]))
                 }
                 else {
-                    dispatch(setErrorPage(ERROR_CODE[500]))
+                    dispatch(setErrorPage(ErrorCode[500]))
                 }
             }
         }

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -51,7 +51,7 @@ function ProfileForm() {
         if (token === null) return
 
         if (!token.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/)) {
-            dispatch(setErrorPage(ErrorCode[404]))
+            dispatch(setErrorPage(ErrorCode.NOT_FOUND))
             return
         }
 
@@ -63,10 +63,10 @@ function ProfileForm() {
             }
             catch (error) {
                 if (error.response.status === 404) {
-                    dispatch(setErrorPage(ErrorCode[404]))
+                    dispatch(setErrorPage(ErrorCode.NOT_FOUND))
                 }
                 else {
-                    dispatch(setErrorPage(ErrorCode[500]))
+                    dispatch(setErrorPage(ErrorCode.INTERNAL_SERVER_ERROR))
                 }
             }
         }

--- a/src/components/Nav/ButtonHome/index.jsx
+++ b/src/components/Nav/ButtonHome/index.jsx
@@ -7,7 +7,7 @@ import Button from '@mui/material/Button';
 import { Box } from '@mui/material';
 import { HashLink } from 'react-router-hash-link';
 import { getErrorPageCode } from '../../../redux/selectors/errorPage';
-import { ERROR_CODE } from '../../../redux/reducers/errorPage';
+import { ErrorCode } from '../../../redux/reducers/errorPage';
 
 import './style.scss';
 
@@ -25,7 +25,7 @@ export default function ButtonHome() {
             {isLog &&
                 (currentPath === '/about' ||
                 currentPath === `/${organizationId}/user/${userId}/edit` ||
-                [ERROR_CODE[403], ERROR_CODE[404], ERROR_CODE[500]].includes(errorCode)) && (
+                [ErrorCode[403], ErrorCode[404], ErrorCode[500]].includes(errorCode)) && (
                 <BasicButton
                     sx={{ display: { xs: 'none', sm: 'block' } }}
                     className="c-button-header_btn"
@@ -53,7 +53,7 @@ export default function ButtonHome() {
                 (currentPath === '/sign-up' ||
                 currentPath === '/new-organization' ||
                 currentPath === '/about' ||
-                [ERROR_CODE[401], ERROR_CODE[404], ERROR_CODE[500]].includes(errorCode)) && (
+                [ErrorCode[401], ErrorCode[404], ErrorCode[500]].includes(errorCode)) && (
                 <Button
                     className="c-button-header_btn"
                     variant="outlined"

--- a/src/components/Nav/ButtonHome/index.jsx
+++ b/src/components/Nav/ButtonHome/index.jsx
@@ -25,7 +25,7 @@ export default function ButtonHome() {
             {isLog &&
                 (currentPath === '/about' ||
                 currentPath === `/${organizationId}/user/${userId}/edit` ||
-                [ErrorCode[403], ErrorCode[404], ErrorCode[500]].includes(errorCode)) && (
+                [ErrorCode.FORBIDDEN, ErrorCode.NOT_FOUND, ErrorCode.INTERNAL_SERVER_ERROR].includes(errorCode)) && (
                 <BasicButton
                     sx={{ display: { xs: 'none', sm: 'block' } }}
                     className="c-button-header_btn"
@@ -53,7 +53,7 @@ export default function ButtonHome() {
                 (currentPath === '/sign-up' ||
                 currentPath === '/new-organization' ||
                 currentPath === '/about' ||
-                [ErrorCode[401], ErrorCode[404], ErrorCode[500]].includes(errorCode)) && (
+                [ErrorCode.UNAUTHORIZED, ErrorCode.NOT_FOUND, ErrorCode.INTERNAL_SERVER_ERROR].includes(errorCode)) && (
                 <Button
                     className="c-button-header_btn"
                     variant="outlined"

--- a/src/components/Router/AdminRoute/index.jsx
+++ b/src/components/Router/AdminRoute/index.jsx
@@ -14,7 +14,7 @@ export default function AdminRoute({ children }) {
     // interruption can lead to strange behaviors and fire an error in console.
     useEffect(() => {
         if (!isAdmin) {
-            dispatch(setErrorPage(ErrorCode[403]))
+            dispatch(setErrorPage(ErrorCode.FORBIDDEN))
         }
     })
 

--- a/src/components/Router/AdminRoute/index.jsx
+++ b/src/components/Router/AdminRoute/index.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import PropTypes from 'prop-types'
 import { useDispatch, useSelector } from 'react-redux'
 import { getIsAdmin } from '../../../redux/selectors/user';
-import { ERROR_CODE, setErrorPage } from '../../../redux/reducers/errorPage';
+import { ErrorCode, setErrorPage } from '../../../redux/reducers/errorPage';
 
 export default function AdminRoute({ children }) {
     const dispatch = useDispatch()
@@ -14,7 +14,7 @@ export default function AdminRoute({ children }) {
     // interruption can lead to strange behaviors and fire an error in console.
     useEffect(() => {
         if (!isAdmin) {
-            dispatch(setErrorPage(ERROR_CODE[403]))
+            dispatch(setErrorPage(ErrorCode[403]))
         }
     })
 

--- a/src/components/Router/GuestRoute/index.jsx
+++ b/src/components/Router/GuestRoute/index.jsx
@@ -14,7 +14,7 @@ export default function GuestRoute({ children }) {
     // interruption can lead to strange behaviors and fire an error in console.
     useEffect(() => {
         if (isLog) {
-            dispatch(setErrorPage(ErrorCode[403]))
+            dispatch(setErrorPage(ErrorCode.FORBIDDEN))
         }
     })
 

--- a/src/components/Router/GuestRoute/index.jsx
+++ b/src/components/Router/GuestRoute/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import { useDispatch, useSelector } from 'react-redux'
 import { getIsLogged } from '../../../redux/selectors/user'
-import { ERROR_CODE, setErrorPage } from '../../../redux/reducers/errorPage'
+import { ErrorCode, setErrorPage } from '../../../redux/reducers/errorPage'
 import { useEffect } from 'react'
 
 export default function GuestRoute({ children }) {
@@ -14,7 +14,7 @@ export default function GuestRoute({ children }) {
     // interruption can lead to strange behaviors and fire an error in console.
     useEffect(() => {
         if (isLog) {
-            dispatch(setErrorPage(ERROR_CODE[403]))
+            dispatch(setErrorPage(ErrorCode[403]))
         }
     })
 

--- a/src/components/Router/NotFoundRoute/index.jsx
+++ b/src/components/Router/NotFoundRoute/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import { useDispatch } from "react-redux"
-import { ERROR_CODE, setErrorPage } from "../../../redux/reducers/errorPage"
+import { ErrorCode, setErrorPage } from "../../../redux/reducers/errorPage"
 
 function NotFoundRoute() {
     const dispatch = useDispatch()
@@ -10,7 +10,7 @@ function NotFoundRoute() {
     // the rendering of every other one inside it once an error is set. Such an
     // interruption can lead to strange behaviors and fire an error in console.
     useEffect(() => {
-        dispatch(setErrorPage(ERROR_CODE[404]))
+        dispatch(setErrorPage(ErrorCode[404]))
     })
 
     return null

--- a/src/components/Router/NotFoundRoute/index.jsx
+++ b/src/components/Router/NotFoundRoute/index.jsx
@@ -10,7 +10,7 @@ function NotFoundRoute() {
     // the rendering of every other one inside it once an error is set. Such an
     // interruption can lead to strange behaviors and fire an error in console.
     useEffect(() => {
-        dispatch(setErrorPage(ErrorCode[404]))
+        dispatch(setErrorPage(ErrorCode.NOT_FOUND))
     })
 
     return null

--- a/src/components/Router/ProtectedRoute/index.jsx
+++ b/src/components/Router/ProtectedRoute/index.jsx
@@ -18,12 +18,12 @@ export default function ProtectedRoute({ children }) {
     // interruption can lead to strange behaviors and fire an error in console.
     useEffect(() => {
         if (!organizationIdIsValid) {
-            dispatch(setErrorPage(ErrorCode[404]))
+            dispatch(setErrorPage(ErrorCode.NOT_FOUND))
             return
         }
 
         if (!isLog) {
-            dispatch(setErrorPage(ErrorCode[401]))
+            dispatch(setErrorPage(ErrorCode.UNAUTHORIZED))
             return
         }
     })

--- a/src/components/Router/ProtectedRoute/index.jsx
+++ b/src/components/Router/ProtectedRoute/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import { useParams } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { getIsLogged } from '../../../redux/selectors/user';
-import { ERROR_CODE, setErrorPage } from '../../../redux/reducers/errorPage';
+import { ErrorCode, setErrorPage } from '../../../redux/reducers/errorPage';
 import { useEffect } from 'react';
 
 export default function ProtectedRoute({ children }) {
@@ -18,12 +18,12 @@ export default function ProtectedRoute({ children }) {
     // interruption can lead to strange behaviors and fire an error in console.
     useEffect(() => {
         if (!organizationIdIsValid) {
-            dispatch(setErrorPage(ERROR_CODE[404]))
+            dispatch(setErrorPage(ErrorCode[404]))
             return
         }
 
         if (!isLog) {
-            dispatch(setErrorPage(ERROR_CODE[401]))
+            dispatch(setErrorPage(ErrorCode[401]))
             return
         }
     })

--- a/src/redux/reducers/errorPage.js
+++ b/src/redux/reducers/errorPage.js
@@ -1,10 +1,10 @@
 import { createSlice } from "@reduxjs/toolkit"
 
 const ErrorCode = {
-    401: 401,
-    403: 403,
-    404: 404,
-    500: 500,
+    UNAUTHORIZED: 401,
+    FORBIDDEN: 403,
+    NOT_FOUND: 404,
+    INTERNAL_SERVER_ERROR: 500,
 }
 
 const initialState = {

--- a/src/redux/reducers/errorPage.js
+++ b/src/redux/reducers/errorPage.js
@@ -1,6 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit"
 
-const ERROR_CODE = {
+const ErrorCode = {
     401: 401,
     403: 403,
     404: 404,
@@ -21,6 +21,6 @@ const slice = createSlice({
     }
 })
 
-export { ERROR_CODE }
+export { ErrorCode }
 export const { setErrorPage } = slice.actions
 export default slice.reducer


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-11-14T10:47:11Z" title="Thursday, November 14th 2024, 11:47:11 am +01:00">Nov 14, 2024</time>_
_Merged <time datetime="2024-11-14T10:47:20Z" title="Thursday, November 14th 2024, 11:47:20 am +01:00">Nov 14, 2024</time>_
---

The ERROR_CODE pseudo enum (it's not a real enum as the app doesn't use TypeScript) was working and doing its job perfectly fine, but its naming didn't respect the convention.

First, enum names should be spelled in PascalCase, but this one was in UPPER_SNAKE_CASE.
Second, their properties should start with a letter an be spelled in UPPER_SNAKE_CASE. Our ERROR_CODE enum contained digits only properties, which is technically possible, but not ideal as accessing them required brackets.

Now the ERROR_CODE enum is spelled ErrorCode, and its properties use the official HTTP status code names, making them more readable and eliminating the need for brackets.