### PR TITLE
All comments loaders appear at same time

### DIFF
--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -122,7 +122,7 @@ function Post({id, author,text,commentsCount,createdAt}) {
                 </ExpandMore>
             </CardContent>
             <Divider/>
-            <CardActions className="c-post-card__action"  disableSpacing>
+            <CardActions className="c-card-post__action"  disableSpacing>
                 <ReactionButton
                     postId={id}   
                 />
@@ -141,7 +141,7 @@ function Post({id, author,text,commentsCount,createdAt}) {
                 </ExpandMore>
             </CardActions>
             <Collapse in={expanded} timeout="auto" unmountOnExit>
-                <CardContent sx={{padding: '0 16px'}} className="c-post-card__list">
+                <CardContent sx={{padding: '0 16px'}} className="c-card-post__list">
                     <Box className="c-card-post__loader">
                         {isLoadingComments ? <CircularProgress/> : null}
                     </Box>

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -142,7 +142,7 @@ function Post({id, author,text,commentsCount,createdAt}) {
             </CardActions>
             <Collapse in={expanded} timeout="auto" unmountOnExit>
                 <CardContent sx={{padding: '0 16px'}} className="c-post-card__list">
-                    <Box className="c-admin-members__loader">
+                    <Box className="c-card-post__loader">
                         {isLoadingComments ? <CircularProgress/> : null}
                     </Box>
                     <List>

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types"
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux'
-import { getPostComments, getPostLoading } from '../../redux/selectors/feed'
+import { getPostComments, getPostIsLoadingComments } from '../../redux/selectors/feed'
 import { fetchComments } from '../../redux/thunks/feed';
 import { getUser } from '../../redux/selectors/user'
 
@@ -50,7 +50,7 @@ function Post({id, author,text,commentsCount,createdAt}) {
 
     // fetch all comments by post    
     const comments = useSelector(getPostComments(id));
-    const commentsLoading = useSelector(getPostLoading)
+    const isLoadingComments = useSelector(getPostIsLoadingComments(id))
 
     const handleExpandClick = () => {
         if (!comments) {
@@ -143,7 +143,7 @@ function Post({id, author,text,commentsCount,createdAt}) {
             <Collapse in={expanded} timeout="auto" unmountOnExit>
                 <CardContent sx={{padding: '0 16px'}} className="c-post-card__list">
                     <Box className="c-admin-members__loader">
-                        {commentsLoading ? <CircularProgress/> : null}
+                        {isLoadingComments ? <CircularProgress/> : null}
                     </Box>
                     <List>
                         {comments?.map(comment => (   

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -142,9 +142,11 @@ function Post({id, author,text,commentsCount,createdAt}) {
             </CardActions>
             <Collapse in={expanded} timeout="auto" unmountOnExit>
                 <CardContent sx={{padding: '0 16px'}} className="c-card-post__list">
-                    <Box className="c-card-post__loader">
-                        {isLoadingComments ? <CircularProgress/> : null}
-                    </Box>
+                    {isLoadingComments &&
+                        <Box className="c-card-post__loader">
+                            <CircularProgress />
+                        </Box>
+                    }
                     <List>
                         {comments?.map(comment => (   
                             <Grid key={comment.id}>

--- a/src/redux/reducers/feed.js
+++ b/src/redux/reducers/feed.js
@@ -36,16 +36,16 @@ const slice = createSlice({
             .addCase(fetchPosts.pending, (state) => {
                 state.loading = true;
             })
-            .addCase(fetchPosts.rejected, (state, action) => {
-                state.error = action.payload
+            .addCase(fetchPosts.rejected, (state, { payload: error }) => {
+                state.error = error
                 state.loading = false;
             })
-            .addCase(createPost.fulfilled, (state, action) => {
-                state.posts.unshift(action.payload)
+            .addCase(createPost.fulfilled, (state, { payload: post }) => {
+                state.posts.unshift(post)
             })
 
-            .addCase(createPost.rejected, (state,action) => {
-                state.error = action.payload
+            .addCase(createPost.rejected, (state, { payload: error }) => {
+                state.error = error
             })
 
             .addCase(fetchComments.fulfilled, (state, { payload: { postId, postComments } } ) => {
@@ -55,8 +55,8 @@ const slice = createSlice({
             .addCase(fetchComments.pending, (state) => {
                 state.loading = true;
             })
-            .addCase(fetchComments.rejected, (state,action) => {
-                state.error = action.payload
+            .addCase(fetchComments.rejected, (state, { payload: error }) => {
+                state.error = error
                 state.loading = false;
             })
 
@@ -65,8 +65,8 @@ const slice = createSlice({
                 post.reactions.push(newReaction)
             })
 
-            .addCase(addReaction.rejected, ( state,action) => {
-                state.error = action.payload
+            .addCase(addReaction.rejected, (state, { payload: error }) => {
+                state.error = error
             })
 
             .addCase(updateReaction.fulfilled, (state, { payload: { postId, reactionId, updatedReaction}}) => {
@@ -75,8 +75,8 @@ const slice = createSlice({
                 post.reactions[reactionIndex] = updatedReaction;
 
             })
-            .addCase(updateReaction.rejected, (state,action) => {
-                state.error = action.payload
+            .addCase(updateReaction.rejected, (state, { payload: error }) => {
+                state.error = error
             })
 
             .addCase(removeReaction.fulfilled, (state, { payload: { postId, reactionId}}) => {
@@ -85,8 +85,8 @@ const slice = createSlice({
                 post.reactions.splice(reactionIndex, 1);
 
             })
-            .addCase(removeReaction.rejected, (state,action) => {
-                state.error = action.payload
+            .addCase(removeReaction.rejected, (state, { payload: error }) => {
+                state.error = error
             })
 
             
@@ -97,8 +97,8 @@ const slice = createSlice({
                 post.commentsCount++
             })
 
-            .addCase(addNewComment.rejected, (state,action) => {
-                state.error = action.payload
+            .addCase(addNewComment.rejected, (state, { payload: error }) => {
+                state.error = error
             })
     },
 });

--- a/src/redux/reducers/feed.js
+++ b/src/redux/reducers/feed.js
@@ -48,7 +48,7 @@ const slice = createSlice({
                 state.error = error
             })
 
-            .addCase(fetchComments.fulfilled, (state, { payload: { postId, postComments } } ) => {
+            .addCase(fetchComments.fulfilled, (state, { payload: { postId, postComments } }) => {
                 state.posts.find(post => post.id === postId).comments = postComments
                 state.loading = false;
             })
@@ -60,7 +60,7 @@ const slice = createSlice({
                 state.loading = false;
             })
 
-            .addCase(addReaction.fulfilled, (state, { payload: { postId, newReaction }}) => {
+            .addCase(addReaction.fulfilled, (state, { payload: { postId, newReaction } }) => {
                 const post = state.posts.find(post => post.id === postId)
                 post.reactions.push(newReaction)
             })
@@ -69,7 +69,7 @@ const slice = createSlice({
                 state.error = error
             })
 
-            .addCase(updateReaction.fulfilled, (state, { payload: { postId, reactionId, updatedReaction}}) => {
+            .addCase(updateReaction.fulfilled, (state, { payload: { postId, reactionId, updatedReaction } }) => {
                 const post = state.posts.find(post => post.id === postId)
                 const reactionIndex = post.reactions.findIndex(reaction => reaction.id === reactionId);
                 post.reactions[reactionIndex] = updatedReaction;
@@ -79,7 +79,7 @@ const slice = createSlice({
                 state.error = error
             })
 
-            .addCase(removeReaction.fulfilled, (state, { payload: { postId, reactionId}}) => {
+            .addCase(removeReaction.fulfilled, (state, { payload: { postId, reactionId } }) => {
                 const post = state.posts.find(post => post.id === postId)
                 const reactionIndex = post.reactions.findIndex(reaction => reaction.id === reactionId);
                 post.reactions.splice(reactionIndex, 1);
@@ -91,7 +91,7 @@ const slice = createSlice({
 
             
 
-            .addCase(addNewComment.fulfilled, (state, { payload: { postId, newComment } } ) => {
+            .addCase(addNewComment.fulfilled, (state, { payload: { postId, newComment } }) => {
                 const post = state.posts.find(post => post.id === postId)
                 post.comments.push(newComment)
                 post.commentsCount++

--- a/src/redux/reducers/members.js
+++ b/src/redux/reducers/members.js
@@ -18,7 +18,7 @@ const slice = createSlice({
     },
     extraReducers: builder => { 
         builder
-            .addCase(fetchMembers.fulfilled,(state, {payload: data}) => {
+            .addCase(fetchMembers.fulfilled,(state, { payload: data }) => {
                 state.list = data,
                 state.loading = false,
                 state.error = null
@@ -26,12 +26,12 @@ const slice = createSlice({
             .addCase(fetchMembers.pending, (state) => {
                 state.loading = true
             })
-            .addCase(fetchMembers.rejected, (state, {payload: error}) => {
+            .addCase(fetchMembers.rejected, (state, { payload: error }) => {
                 state.loading = false,
                 state.error = error
             })
 
-            .addCase(updateMemberStatus.fulfilled,(state, {payload: data}) => {
+            .addCase(updateMemberStatus.fulfilled,(state, { payload: data }) => {
                 
                 state.list.find(member => member.id === data.id).disabled = data.disabled
 
@@ -40,7 +40,7 @@ const slice = createSlice({
             .addCase(updateMemberStatus.pending, (state) => {
                 state.loading = true
             })
-            .addCase(updateMemberStatus.rejected, (state, {payload: error}) => {
+            .addCase(updateMemberStatus.rejected, (state, { payload: error }) => {
                 state.error = error
                 state.loading = false
             })

--- a/src/redux/reducers/user.js
+++ b/src/redux/reducers/user.js
@@ -36,8 +36,8 @@ const slice = createSlice({
             .addCase(login.pending, (state) => {
                 state.loading = true;
             })
-            .addCase(login.rejected, (state, action) => {
-                state.error = action.payload
+            .addCase(login.rejected, (state, { payload: error }) => {
+                state.error = error
                 state.loading = false;
             })
 

--- a/src/redux/reducers/user.js
+++ b/src/redux/reducers/user.js
@@ -23,13 +23,13 @@ const slice = createSlice({
         cleanUserState(state) {
             Object.assign(state, initialState);
         },
-        setError(state, {payload: error }){
+        setError(state, { payload: error }){
             state.error = error
         }
     },
     extraReducers: builder => { 
         builder
-            .addCase(login.fulfilled, (state, {payload: user}) => {
+            .addCase(login.fulfilled, (state, { payload: user }) => {
                 return { ...state, ...user, error: null, loading: false,
                 };
             })
@@ -55,13 +55,13 @@ const slice = createSlice({
             .addCase(addUser.fulfilled,state => {
                 state.error= null
             })
-            .addCase(addUser.rejected, (state, {payload: error}) => {
+            .addCase(addUser.rejected, (state, { payload: error }) => {
                 state.error = error
             })
-            .addCase(updateUser.fulfilled,(state, {payload: data}) => {
+            .addCase(updateUser.fulfilled,(state, { payload: data }) => {
                 return {...state, ...data, error: null}
             })
-            .addCase(updateUser.rejected, (state, {payload: error}) => {
+            .addCase(updateUser.rejected, (state, { payload: error }) => {
                 state.error = error
             })
     },

--- a/src/redux/selectors/feed.js
+++ b/src/redux/selectors/feed.js
@@ -19,6 +19,8 @@ export const getPostLoading = state => getFeed(state).loading;
     }
 }*/
 
+export const getPostIsLoadingComments = postId => state => getPost(postId)(state).isLoadingComments
+
 export const  getPostComments = postId => state => getPost(postId)(state).comments;
 
 export const getPostReactions = postId => state => getPost(postId)(state).reactions;


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-11-18T11:42:28Z" title="Monday, November 18th 2024, 12:42:28 pm +01:00">Nov 18, 2024</time>_
_Merged <time datetime="2024-11-18T11:42:47Z" title="Monday, November 18th 2024, 12:42:47 pm +01:00">Nov 18, 2024</time>_
---

Previously, the `loading` state of the `feed` reducer was shared between posts and comments, which caused issues since there is only one feed but multiple posts. When the user opened the comments section of a post, all posts with opened comments section incorrectly displayed a loader at the same time.

Now, each post has its own loading state for comments, ensuring the loader appears only for the relevant post.

Additionally, some small fixes and refactoring have been included in this branch to refine the loader surroundings, including:
- generalization of reducers parameters destructuring
- some fixes in the BEM class names of the Post component
- removal of an unnecessary gap before the comments list (where the loader live)