### PR TITLE
Fix comment section staying incorrectly open on error after comment fetch

### DIFF
--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -52,12 +52,18 @@ function Post({id, author,text,commentsCount,createdAt}) {
     const comments = useSelector(getPostComments(id));
     const isLoadingComments = useSelector(getPostIsLoadingComments(id))
 
-    const handleExpandClick = () => {
-        if (!comments) {
-            dispatch(fetchComments(id));
-        }
-
+    const handleExpandClick = async () => {
         setExpanded(!expanded);
+
+        if (!comments) {
+            try {
+                await dispatch(fetchComments(id)).unwrap();
+            }
+            catch (error) {
+                setExpanded(false)
+                console.error(error); // TODO: instead of console logs, errors must be displayed directly to user
+            }
+        }
     };
 
     return (


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-11-18T17:17:44Z" title="Monday, November 18th 2024, 6:17:44 pm +01:00">Nov 18, 2024</time>_
_Merged <time datetime="2024-11-18T17:17:54Z" title="Monday, November 18th 2024, 6:17:54 pm +01:00">Nov 18, 2024</time>_
---

When an error occurred while fetching comments, the comments section remained open, requiring the user to click twice (once to close it and once again to reopen it) to retry the request. Now, the comments section automatically closes on error, allowing the user to relaunch the request with a single click, which feels more intuitive.