### PR TITLE
Better names in thunks

### DIFF
--- a/src/components/Buttons/ReactionButton/index.jsx
+++ b/src/components/Buttons/ReactionButton/index.jsx
@@ -34,15 +34,15 @@ function ReactionButton({postId}) {
     const open = Boolean(anchorEl);
     const id = open ? 'simple-popover' : undefined;
 
-    const handleReaction = (reaction)=>{
-        if (loggedUserReaction && loggedUserReaction.type.tag === reaction){
+    const handleReaction = (type)=>{
+        if (loggedUserReaction && loggedUserReaction.type.tag === type){
             dispatch(removeReaction({postId, reactionId: loggedUserReaction.id}))
         }
         else if (loggedUserReaction){
-            dispatch(updateReaction({postId, reaction, reactionId: loggedUserReaction.id}))
+            dispatch(updateReaction({postId, type, reactionId: loggedUserReaction.id}))
         }
         else {
-            dispatch(createReaction({postId, reaction}))
+            dispatch(createReaction({postId, type}))
         }
         setAnchorEl(null);
     }

--- a/src/components/Buttons/ReactionButton/index.jsx
+++ b/src/components/Buttons/ReactionButton/index.jsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { getPostReactions } from '../../../redux/selectors/feed';
 import { getUserId } from '../../../redux/selectors/user';
-import { addReaction, updateReaction, removeReaction } from '../../../redux/thunks/feed';
+import { createReaction, updateReaction, removeReaction } from '../../../redux/thunks/feed';
 import './style.scss'
 
 
@@ -42,7 +42,7 @@ function ReactionButton({postId}) {
             dispatch(updateReaction({postId, reaction, reactionId: loggedUserReaction.id}))
         }
         else {
-            dispatch(addReaction({postId, reaction}))
+            dispatch(createReaction({postId, reaction}))
         }
         setAnchorEl(null);
     }

--- a/src/components/Forms/CommentForm/index.jsx
+++ b/src/components/Forms/CommentForm/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types"
 import { useForm } from 'react-hook-form'
 import { useDispatch} from 'react-redux'
 
-import { addNewComment } from '../../../redux/thunks/feed';
+import { createComment } from '../../../redux/thunks/feed';
 
 import { Paper, InputBase } from '@mui/material'
 import { IconButton } from '@mui/material'
@@ -17,7 +17,7 @@ function CommentForm({postId}) {
 
     const onSubmit = ({text}) => {
     
-        dispatch(addNewComment({text, postId}));
+        dispatch(createComment({text, postId}));
         reset();
         
     };

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -1,7 +1,7 @@
 import AvatarForm from "../AvatarForm";
 import { Box, Button, CircularProgress, TextField, Typography } from '@mui/material';
 import { grey } from "@mui/material/colors";
-import { addUser, updateUser } from '../../../redux/reducers/user'
+import { createUser, updateUser } from '../../../redux/reducers/user'
 import { getUser, getIsLogged, getUserError } from '../../../redux/selectors/user'
 import { useDispatch, useSelector } from 'react-redux';
 import { useForm } from "react-hook-form";
@@ -111,7 +111,7 @@ function ProfileForm() {
         }
 
         try {
-            await dispatch(addUser(data)).unwrap()
+            await dispatch(createUser(data)).unwrap()
             navigate(`/`)
         }
         catch (error) {

--- a/src/redux/reducers/feed.js
+++ b/src/redux/reducers/feed.js
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { fetchPosts, fetchComments, createPost, addNewComment, addReaction, updateReaction, removeReaction} from '../thunks/feed'
+import { fetchPosts, fetchComments, createPost, createComment, createReaction, updateReaction, removeReaction} from '../thunks/feed'
 
 
 
@@ -65,12 +65,12 @@ const slice = createSlice({
                 state.posts.find(post => post.id === postId).isLoadingComments = false;
             })
 
-            .addCase(addReaction.fulfilled, (state, { payload: { postId, newReaction } }) => {
+            .addCase(createReaction.fulfilled, (state, { payload: { postId, newReaction } }) => {
                 const post = state.posts.find(post => post.id === postId)
                 post.reactions.push(newReaction)
             })
 
-            .addCase(addReaction.rejected, (state, { payload: error }) => {
+            .addCase(createReaction.rejected, (state, { payload: error }) => {
                 state.error = error
             })
 
@@ -96,13 +96,13 @@ const slice = createSlice({
 
             
 
-            .addCase(addNewComment.fulfilled, (state, { payload: { postId, newComment } }) => {
+            .addCase(createComment.fulfilled, (state, { payload: { postId, newComment } }) => {
                 const post = state.posts.find(post => post.id === postId)
                 post.comments.push(newComment)
                 post.commentsCount++
             })
 
-            .addCase(addNewComment.rejected, (state, { payload: error }) => {
+            .addCase(createComment.rejected, (state, { payload: error }) => {
                 state.error = error
             })
     },

--- a/src/redux/reducers/feed.js
+++ b/src/redux/reducers/feed.js
@@ -65,19 +65,19 @@ const slice = createSlice({
                 state.posts.find(post => post.id === postId).isLoadingComments = false;
             })
 
-            .addCase(createReaction.fulfilled, (state, { payload: { postId, newReaction } }) => {
+            .addCase(createReaction.fulfilled, (state, { payload: { postId, reaction } }) => {
                 const post = state.posts.find(post => post.id === postId)
-                post.reactions.push(newReaction)
+                post.reactions.push(reaction)
             })
 
             .addCase(createReaction.rejected, (state, { payload: error }) => {
                 state.error = error
             })
 
-            .addCase(updateReaction.fulfilled, (state, { payload: { postId, reactionId, updatedReaction } }) => {
+            .addCase(updateReaction.fulfilled, (state, { payload: { postId, reactionId, reaction } }) => {
                 const post = state.posts.find(post => post.id === postId)
                 const reactionIndex = post.reactions.findIndex(reaction => reaction.id === reactionId);
-                post.reactions[reactionIndex] = updatedReaction;
+                post.reactions[reactionIndex] = reaction;
 
             })
             .addCase(updateReaction.rejected, (state, { payload: error }) => {

--- a/src/redux/reducers/user.js
+++ b/src/redux/reducers/user.js
@@ -1,6 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { login, logout, fetchUser } from "../thunks/user";
-import { addUser, updateUser } from "../../redux/thunks/user"
+import { createUser, updateUser } from "../../redux/thunks/user"
 
 export const initialState = {
     id: null,
@@ -52,10 +52,10 @@ const slice = createSlice({
                 return { ...state, ...user  }
             })
 
-            .addCase(addUser.fulfilled,state => {
+            .addCase(createUser.fulfilled,state => {
                 state.error= null
             })
-            .addCase(addUser.rejected, (state, { payload: error }) => {
+            .addCase(createUser.rejected, (state, { payload: error }) => {
                 state.error = error
             })
             .addCase(updateUser.fulfilled,(state, { payload: data }) => {
@@ -69,4 +69,4 @@ const slice = createSlice({
 
 export default slice.reducer
 export const {cleanUserState, setError} = slice.actions
-export {login, logout, fetchUser, addUser, updateUser}
+export {login, logout, fetchUser, createUser, updateUser}

--- a/src/redux/thunks/feed.js
+++ b/src/redux/thunks/feed.js
@@ -75,7 +75,7 @@ export const addNewComment = createAsyncThunk("feed/addNewComment", async ({text
 })
 
 
-export const addReaction = createAsyncThunk("post/addReaction", async ({postId, reaction}, thunkApi) => {
+export const addReaction = createAsyncThunk("feed/addReaction", async ({postId, reaction}, thunkApi) => {
     try {
         await fetchCsrfCookie()
         const { data : newReaction } = await api.post(`/posts/${postId}/reactions`,  {type: reaction})
@@ -95,7 +95,7 @@ export const addReaction = createAsyncThunk("post/addReaction", async ({postId, 
 
 
 
-export const updateReaction = createAsyncThunk("post/updateReaction", async ({postId, reaction, reactionId}, thunkApi) => {
+export const updateReaction = createAsyncThunk("feed/updateReaction", async ({postId, reaction, reactionId}, thunkApi) => {
 
     try {
         await fetchCsrfCookie()
@@ -112,7 +112,7 @@ export const updateReaction = createAsyncThunk("post/updateReaction", async ({po
 })
 
 
-export const removeReaction = createAsyncThunk("post/removeReaction", async ({postId, reactionId}, thunkApi) => {
+export const removeReaction = createAsyncThunk("feed/removeReaction", async ({postId, reactionId}, thunkApi) => {
 
     try {
         await fetchCsrfCookie()

--- a/src/redux/thunks/feed.js
+++ b/src/redux/thunks/feed.js
@@ -75,12 +75,12 @@ export const createComment = createAsyncThunk("feed/createComment", async ({text
 })
 
 
-export const createReaction = createAsyncThunk("feed/createReaction", async ({postId, reaction}, thunkApi) => {
+export const createReaction = createAsyncThunk("feed/createReaction", async ({postId, type}, thunkApi) => {
     try {
         await fetchCsrfCookie()
-        const { data : newReaction } = await api.post(`/posts/${postId}/reactions`,  {type: reaction})
+        const { data: reaction } = await api.post(`/posts/${postId}/reactions`,  { type })
 
-        return {newReaction, postId}
+        return { reaction, postId }
     }
     catch (error) {
         if (error.response.status === 404){
@@ -95,13 +95,13 @@ export const createReaction = createAsyncThunk("feed/createReaction", async ({po
 
 
 
-export const updateReaction = createAsyncThunk("feed/updateReaction", async ({postId, reaction, reactionId}, thunkApi) => {
+export const updateReaction = createAsyncThunk("feed/updateReaction", async ({postId, type, reactionId}, thunkApi) => {
 
     try {
         await fetchCsrfCookie()
-        const { data : updatedReaction } = await api.patch(`/reactions/${reactionId}`,  {type: reaction})
+        const { data: reaction } = await api.patch(`/reactions/${reactionId}`,  { type })
     
-        return {updatedReaction, postId, reactionId}
+        return { reaction, postId, reactionId }
     }
     catch (error) { 
         if (error.response.status === 404){

--- a/src/redux/thunks/feed.js
+++ b/src/redux/thunks/feed.js
@@ -59,7 +59,7 @@ export const fetchComments = createAsyncThunk("feed/fetchComments", async (postI
 })
 
 
-export const addNewComment = createAsyncThunk("feed/addNewComment", async ({text, postId}, thunkApi) => {
+export const createComment = createAsyncThunk("feed/createComment", async ({text, postId}, thunkApi) => {
     try {
         await fetchCsrfCookie()
         const { data : newComment } = await api.post(`/posts/${postId}/comments`,  {text: text})
@@ -75,7 +75,7 @@ export const addNewComment = createAsyncThunk("feed/addNewComment", async ({text
 })
 
 
-export const addReaction = createAsyncThunk("feed/addReaction", async ({postId, reaction}, thunkApi) => {
+export const createReaction = createAsyncThunk("feed/createReaction", async ({postId, reaction}, thunkApi) => {
     try {
         await fetchCsrfCookie()
         const { data : newReaction } = await api.post(`/posts/${postId}/reactions`,  {type: reaction})

--- a/src/redux/thunks/members.js
+++ b/src/redux/thunks/members.js
@@ -19,7 +19,7 @@ export const fetchMembers = createAsyncThunk("members/fetchMembers", async (orga
     }
 })
 
-export const updateMemberStatus = createAsyncThunk("user/updateMemberStatus", async ({ id, disabled }, thunkAPI) => {
+export const updateMemberStatus = createAsyncThunk("members/updateMemberStatus", async ({ id, disabled }, thunkAPI) => {
     try {
         await fetchCsrfCookie()
 

--- a/src/redux/thunks/user.js
+++ b/src/redux/thunks/user.js
@@ -1,7 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { api, fetchCsrfCookie } from "../../services/api"
 
-export const login = createAsyncThunk("users/login", async (credentials, thunkApi) => {
+export const login = createAsyncThunk("user/login", async (credentials, thunkApi) => {
 
     try {
         await fetchCsrfCookie()
@@ -32,7 +32,7 @@ export const login = createAsyncThunk("users/login", async (credentials, thunkAp
     }
 })
 
-export const logout = createAsyncThunk("users/logout", async (_, thunkApi) => {
+export const logout = createAsyncThunk("user/logout", async (_, thunkApi) => {
 
     try {
         await fetchCsrfCookie()

--- a/src/redux/thunks/user.js
+++ b/src/redux/thunks/user.js
@@ -62,7 +62,7 @@ export const fetchUser = createAsyncThunk('user/fetchUser', async (_, thunkApi) 
     }
 })
 
-export const addUser = createAsyncThunk("user/addUser", async (data, thunkAPI) => {
+export const createUser = createAsyncThunk("user/createUser", async (data, thunkAPI) => {
     try {
         await fetchCsrfCookie()
 


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-11-25T17:14:20Z" title="Monday, November 25th 2024, 6:14:20 pm +01:00">Nov 25, 2024</time>_
_Merged <time datetime="2024-11-25T17:14:41Z" title="Monday, November 25th 2024, 6:14:41 pm +01:00">Nov 25, 2024</time>_
---

Many variables, parameters and properties in the Redux thunks were inconsistent. Here are a few examples:
- Some thunk names did not use the reducer name as a prefix (e.g., `post/updateReaction` in the `feed` reducer).
- Most reducers used to create resources on the server were inconsistently named (e.g., sometimes `createX`, sometimes `addX`...).
- The `feed/createReaction` and `feed/updateReaction` thunks used the name `reaction` to represent both complete reaction models and just their type.

These inconsistencies have been fixed in this PR, resulting in a smoother developer experience.