### PR TITLE
Fix home page flash after profile update

### DIFF
--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -150,7 +150,7 @@ function ProfileForm() {
 
         try {
             await dispatch(updateUser(data)).unwrap()
-            navigate(`/`)
+            navigate(`/${user.organization.id}`)
         }
         catch (error) {
             setGlobalFormError(error)


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2024-12-09T17:51:41Z" title="Monday, December 9th 2024, 6:51:41 pm +01:00">Dec 9, 2024</time>_
_Merged <time datetime="2024-12-09T17:51:52Z" title="Monday, December 9th 2024, 6:51:52 pm +01:00">Dec 9, 2024</time>_
---

After updating their profile, users were correctly redirected to their organization feed page, but the home page briefly flashed beforehand. This happened because the `navigate` function was mistakenly pointing to the home page right after the server response. However, the `LoginForm` component automatically redirects authenticated users to their organization, making the problem less obvious.

Now, this issue is fixed, and users are seamlessly redirected to their organization home page after updating their profile.