### PR TITLE
Fix missing prop-types direct dependency

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,7 @@ module.exports = {
         quotes: [1, 'single', { allowTemplateLiterals: true }],
         'import/named': 1,
         'import/order': [1, { 'newlines-between': 'never' }],
+        'import/no-extraneous-dependencies': 1,
         'import/newline-after-import': 1,
         'import/no-useless-path-segments': [1, { noUselessIndex: true }],
         'import/no-default-export': 1,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-react-refresh": "^0.4.1",
     "moment": "^2.29.4",
     "pluralize": "^8.0.0",
+    "prop-types": "^15.8.1",
     "react-hook-form": "^7.45.1",
     "react-redux": "^8.1.1",
     "react-router-dom": "^6.14.1",


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2025-02-17T11:50:45Z" title="Monday, February 17th 2025, 12:50:45 pm +01:00">Feb 17, 2025</time>_
_Merged <time datetime="2025-02-17T11:51:12Z" title="Monday, February 17th 2025, 12:51:12 pm +01:00">Feb 17, 2025</time>_
---

`PropTypes` has been used in the app since the start of the project, but it was never installed as a direct dependency. Instead, it was only a sub-dependency of `react-router-hash-link` and MUI.

In fact, sub-dependencies can be imported just like any other, but this comes with the risk of breaking the app if their parent dependencies are updated or removed. To help enforce this standard, the `import/no-extraneous-dependencies` rule has been activated in ESLint.