### PR TITLE
PropTypes and exports standardization

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,6 +32,7 @@ module.exports = {
             asyncArrow: 'always'
         }],
         'arrow-parens': [1, 'as-needed'],
+        'react/no-unused-prop-types': 1,
         'react/function-component-definition': 1,
         'react/no-unescaped-entities': [1, { forbid: ['>', '}'] }],
         'react/jsx-equals-spacing': [1, 'never'],

--- a/src/components/Admin/AdminMembers/index.jsx
+++ b/src/components/Admin/AdminMembers/index.jsx
@@ -8,7 +8,7 @@ import { getUserId, getUserOrganizationId } from '../../../redux/selectors/user'
 
 import './style.scss'
 
-function AdminMembers() {
+export function AdminMembers() {
     const [members, setMembers] = useState([])
     const organizationId = useSelector(getUserOrganizationId)
     const userId = useSelector(getUserId)
@@ -98,5 +98,3 @@ function AdminMembers() {
         </Box>
     )
 }
-
-export { AdminMembers }

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -6,7 +6,7 @@ import { LoadingLayout } from '../../layout/LoadingLayout'
 import { ErrorPageHandler } from '../Router/ErrorPageHandler'
 import { ErrorCode, setErrorPage } from '../../redux/reducers/errorPage'
 
-function App() {
+export function App() {
     const dispatch = useDispatch()
     const [isFetchingUser, setIsFetchingUser] = useState(true)
 
@@ -30,5 +30,3 @@ function App() {
             </ErrorPageHandler>
     )
 }
-
-export { App }

--- a/src/components/Buttons/BasicButton/index.jsx
+++ b/src/components/Buttons/BasicButton/index.jsx
@@ -2,6 +2,15 @@ import PropTypes from 'prop-types'
 import Button from '@mui/material/Button'
 import './style.scss'
 
+BasicButton.propTypes = {
+    sx: PropTypes.object,
+    className: PropTypes.string,
+    variant: PropTypes.string,
+    name: PropTypes.string,
+    component: PropTypes.object,
+    route: PropTypes.string
+}
+
 export function BasicButton({ sx, className, variant, name, component, route }) {
     return (
         <Button
@@ -13,13 +22,4 @@ export function BasicButton({ sx, className, variant, name, component, route }) 
             {name}
         </Button>
     )
-}
-
-BasicButton.propTypes = {
-    sx: PropTypes.object,
-    className: PropTypes.string,
-    variant: PropTypes.string,
-    name: PropTypes.string,
-    component: PropTypes.object,
-    route: PropTypes.string
 }

--- a/src/components/Buttons/ReactionButton/index.jsx
+++ b/src/components/Buttons/ReactionButton/index.jsx
@@ -9,7 +9,7 @@ import { getUserId } from '../../../redux/selectors/user'
 import { createReaction, updateReaction, removeReaction } from '../../../redux/thunks/feed'
 import './style.scss'
 
-function ReactionButton({ postId }) {
+export function ReactionButton({ postId }) {
     const [anchorEl, setAnchorEl] = useState(null)
     const dispatch = useDispatch()
     const postReactions = useSelector(getPostReactions(postId))
@@ -89,5 +89,3 @@ function ReactionButton({ postId }) {
 ReactionButton.propTypes = {
     postId: PropTypes.number.isRequired
 }
-
-export { ReactionButton }

--- a/src/components/Buttons/ReactionButton/index.jsx
+++ b/src/components/Buttons/ReactionButton/index.jsx
@@ -9,6 +9,10 @@ import { getUserId } from '../../../redux/selectors/user'
 import { createReaction, updateReaction, removeReaction } from '../../../redux/thunks/feed'
 import './style.scss'
 
+ReactionButton.propTypes = {
+    postId: PropTypes.number.isRequired
+}
+
 export function ReactionButton({ postId }) {
     const [anchorEl, setAnchorEl] = useState(null)
     const dispatch = useDispatch()
@@ -84,8 +88,4 @@ export function ReactionButton({ postId }) {
         </div>
 
     )
-}
-
-ReactionButton.propTypes = {
-    postId: PropTypes.number.isRequired
 }

--- a/src/components/Buttons/ScrollTopButton/index.jsx
+++ b/src/components/Buttons/ScrollTopButton/index.jsx
@@ -3,7 +3,7 @@ import { Box, Fab, Fade } from '@mui/material'
 import useScrollTrigger from '@mui/material/useScrollTrigger'
 
 // buton to scroll to top
-function ScrollTopButton() {
+export function ScrollTopButton() {
     const trigger = useScrollTrigger({
         target: window,
         disableHysteresis: true,
@@ -37,5 +37,3 @@ function ScrollTopButton() {
         </Fade>
     )
 }
-
-export { ScrollTopButton }

--- a/src/components/Cards/MemberCard/index.jsx
+++ b/src/components/Cards/MemberCard/index.jsx
@@ -6,7 +6,7 @@ import CircularProgress from '@mui/material/CircularProgress'
 import { api, fetchCsrfCookie } from '../../../services/api'
 import './style.scss'
 
-function MemberCard({ id, organization, name, surname, job, profilePicture, disabled, setMember }) {
+export function MemberCard({ id, organization, name, surname, job, profilePicture, disabled, setMember }) {
     const [isLoading, setIsLoading] = useState(false)
 
     const onStatusButtonClick = async () => {
@@ -115,5 +115,3 @@ MemberCard.propTypes = {
     disabled: PropTypes.bool,
     setMember: PropTypes.func.isRequired
 }
-
-export { MemberCard }

--- a/src/components/Cards/MemberCard/index.jsx
+++ b/src/components/Cards/MemberCard/index.jsx
@@ -6,6 +6,20 @@ import CircularProgress from '@mui/material/CircularProgress'
 import { api, fetchCsrfCookie } from '../../../services/api'
 import './style.scss'
 
+MemberCard.propTypes = {
+    id: PropTypes.number,
+    organization: PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        name: PropTypes.string.isRequired
+    }).isRequired,
+    name: PropTypes.string,
+    surname: PropTypes.string,
+    job: PropTypes.string,
+    profilePicture: PropTypes.string,
+    disabled: PropTypes.bool,
+    setMember: PropTypes.func.isRequired
+}
+
 export function MemberCard({ id, organization, name, surname, job, profilePicture, disabled, setMember }) {
     const [isLoading, setIsLoading] = useState(false)
 
@@ -100,18 +114,4 @@ export function MemberCard({ id, organization, name, surname, job, profilePictur
             </Button>
         </Paper>
     )
-}
-
-MemberCard.propTypes = {
-    id: PropTypes.number,
-    organization: PropTypes.shape({
-        id: PropTypes.number.isRequired,
-        name: PropTypes.string.isRequired
-    }).isRequired,
-    name: PropTypes.string,
-    surname: PropTypes.string,
-    job: PropTypes.string,
-    profilePicture: PropTypes.string,
-    disabled: PropTypes.bool,
-    setMember: PropTypes.func.isRequired
 }

--- a/src/components/Cards/SelectedUserCard/index.jsx
+++ b/src/components/Cards/SelectedUserCard/index.jsx
@@ -5,7 +5,7 @@ import { api } from '../../../services/api'
 
 import './style.scss'
 
-function SelectedUserCard() {
+export function SelectedUserCard() {
     const userId = parseInt(useParams().userId, 10)
     const [selectedMember, setSelectedMember] = useState(null)
     const [isLoading, setIsLoading] = useState(true)
@@ -90,5 +90,3 @@ function SelectedUserCard() {
         </Box>
     )
 }
-
-export { SelectedUserCard }

--- a/src/components/Cards/UserCard/index.jsx
+++ b/src/components/Cards/UserCard/index.jsx
@@ -5,7 +5,7 @@ import { getUser } from '../../../redux/selectors/user'
 
 import './style.scss'
 
-function UserCard() {
+export function UserCard() {
     const userLogged = useSelector(getUser)
 
     return (
@@ -64,5 +64,3 @@ function UserCard() {
         </MuiLink>
     )
 }
-
-export { UserCard }

--- a/src/components/Comment/index.jsx
+++ b/src/components/Comment/index.jsx
@@ -4,7 +4,7 @@ import { ListItem, ListItemAvatar, Paper, Avatar, Typography, Link as MuiLink } 
 import './style.scss'
 import { Link } from 'react-router-dom'
 
-function Comment({ author, text, createdAt }) {
+export function Comment({ author, text, createdAt }) {
     // Date and time reformatting
     const date = moment(createdAt).format('DD/MM/YYYY')
     const time = moment(createdAt).format('HH[h]mm')
@@ -56,5 +56,3 @@ Comment.propTypes = {
     text: PropTypes.string,
     createdAt: PropTypes.string
 }
-
-export { Comment }

--- a/src/components/Comment/index.jsx
+++ b/src/components/Comment/index.jsx
@@ -4,6 +4,12 @@ import { ListItem, ListItemAvatar, Paper, Avatar, Typography, Link as MuiLink } 
 import './style.scss'
 import { Link } from 'react-router-dom'
 
+Comment.propTypes = {
+    author: PropTypes.object,
+    text: PropTypes.string,
+    createdAt: PropTypes.string
+}
+
 export function Comment({ author, text, createdAt }) {
     // Date and time reformatting
     const date = moment(createdAt).format('DD/MM/YYYY')
@@ -49,10 +55,4 @@ export function Comment({ author, text, createdAt }) {
             </Paper>
         </ListItem>
     )
-}
-
-Comment.propTypes = {
-    author: PropTypes.object,
-    text: PropTypes.string,
-    createdAt: PropTypes.string
 }

--- a/src/components/Feed/index.jsx
+++ b/src/components/Feed/index.jsx
@@ -13,7 +13,7 @@ import { FeedPlaceholder } from '../FeedPlaceholder'
 
 import './style.scss'
 
-function Feed({ userIdUrl }) {
+export function Feed({ userIdUrl }) {
     // Fetch of logged-in user data
     const dispatch = useDispatch()
     const userLogged = useSelector(getUser)
@@ -101,5 +101,3 @@ function Feed({ userIdUrl }) {
 Feed.propTypes = {
     userIdUrl: PropTypes.number
 }
-
-export { Feed }

--- a/src/components/Feed/index.jsx
+++ b/src/components/Feed/index.jsx
@@ -13,6 +13,10 @@ import { FeedPlaceholder } from '../FeedPlaceholder'
 
 import './style.scss'
 
+Feed.propTypes = {
+    userIdUrl: PropTypes.number
+}
+
 export function Feed({ userIdUrl }) {
     // Fetch of logged-in user data
     const dispatch = useDispatch()
@@ -96,8 +100,4 @@ export function Feed({ userIdUrl }) {
 
         </Box>
     )
-}
-
-Feed.propTypes = {
-    userIdUrl: PropTypes.number
 }

--- a/src/components/FeedPlaceholder/index.jsx
+++ b/src/components/FeedPlaceholder/index.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux'
 import { Typography } from '@mui/material'
 import { getPosts } from '../../redux/selectors/feed'
 
-function FeedPlaceholder({ userId }) {
+export function FeedPlaceholder({ userId }) {
     const posts = useSelector(getPosts)
 
     return (
@@ -21,5 +21,3 @@ function FeedPlaceholder({ userId }) {
 FeedPlaceholder.propTypes = {
     userId: PropTypes.number
 }
-
-export { FeedPlaceholder }

--- a/src/components/FeedPlaceholder/index.jsx
+++ b/src/components/FeedPlaceholder/index.jsx
@@ -3,6 +3,10 @@ import { useSelector } from 'react-redux'
 import { Typography } from '@mui/material'
 import { getPosts } from '../../redux/selectors/feed'
 
+FeedPlaceholder.propTypes = {
+    userId: PropTypes.number
+}
+
 export function FeedPlaceholder({ userId }) {
     const posts = useSelector(getPosts)
 
@@ -16,8 +20,4 @@ export function FeedPlaceholder({ userId }) {
             }
         </Typography>
     )
-}
-
-FeedPlaceholder.propTypes = {
-    userId: PropTypes.number
 }

--- a/src/components/Forms/AvatarForm/index.jsx
+++ b/src/components/Forms/AvatarForm/index.jsx
@@ -9,7 +9,7 @@ import { getUser } from '../../../redux/selectors/user'
 
 import './style.scss'
 
-function AvatarForm({ control, resetField, onDeletePictureChange }) {
+export function AvatarForm({ control, resetField, onDeletePictureChange }) {
     const user = (useSelector(getUser))
     const currentProfilePicture = user.profilePicture
 
@@ -116,5 +116,3 @@ AvatarForm.propTypes = {
     resetField: PropTypes.func.isRequired,
     onDeletePictureChange: PropTypes.func.isRequired
 }
-
-export { AvatarForm }

--- a/src/components/Forms/AvatarForm/index.jsx
+++ b/src/components/Forms/AvatarForm/index.jsx
@@ -9,6 +9,12 @@ import { getUser } from '../../../redux/selectors/user'
 
 import './style.scss'
 
+AvatarForm.propTypes = {
+    control: PropTypes.object.isRequired,
+    resetField: PropTypes.func.isRequired,
+    onDeletePictureChange: PropTypes.func.isRequired
+}
+
 export function AvatarForm({ control, resetField, onDeletePictureChange }) {
     const user = (useSelector(getUser))
     const currentProfilePicture = user.profilePicture
@@ -109,10 +115,4 @@ export function AvatarForm({ control, resetField, onDeletePictureChange }) {
             )}
         </Box>
     )
-}
-
-AvatarForm.propTypes = {
-    control: PropTypes.object.isRequired,
-    resetField: PropTypes.func.isRequired,
-    onDeletePictureChange: PropTypes.func.isRequired
 }

--- a/src/components/Forms/CommentForm/index.jsx
+++ b/src/components/Forms/CommentForm/index.jsx
@@ -6,7 +6,7 @@ import SendIcon from '@mui/icons-material/Send'
 import { createComment } from '../../../redux/thunks/feed'
 import './style.scss'
 
-function CommentForm({ postId }) {
+export function CommentForm({ postId }) {
     const { register, handleSubmit, reset } = useForm()
 
     const dispatch = useDispatch()
@@ -43,5 +43,3 @@ function CommentForm({ postId }) {
 CommentForm.propTypes = {
     postId: PropTypes.number
 }
-
-export { CommentForm }

--- a/src/components/Forms/CommentForm/index.jsx
+++ b/src/components/Forms/CommentForm/index.jsx
@@ -6,6 +6,10 @@ import SendIcon from '@mui/icons-material/Send'
 import { createComment } from '../../../redux/thunks/feed'
 import './style.scss'
 
+CommentForm.propTypes = {
+    postId: PropTypes.number
+}
+
 export function CommentForm({ postId }) {
     const { register, handleSubmit, reset } = useForm()
 
@@ -38,8 +42,4 @@ export function CommentForm({ postId }) {
             </IconButton>
         </Paper>
     )
-}
-
-CommentForm.propTypes = {
-    postId: PropTypes.number
 }

--- a/src/components/Forms/InvitForm/index.jsx
+++ b/src/components/Forms/InvitForm/index.jsx
@@ -6,7 +6,7 @@ import { useServerErrors } from '../useServerErrors'
 import { api, fetchCsrfCookie } from '../../../services/api'
 import './style.scss'
 
-function InvitForm() {
+export function InvitForm() {
     // const dispatch = useDispatch();
 
     const [isLoading, setIsLoading] = useState(false)
@@ -92,5 +92,3 @@ function InvitForm() {
         </Box>
     )
 }
-
-export { InvitForm }

--- a/src/components/Forms/LoginForm/index.jsx
+++ b/src/components/Forms/LoginForm/index.jsx
@@ -7,7 +7,7 @@ import { login } from '../../../redux/reducers/user'
 
 import './style.scss'
 
-function LoginForm() {
+export function LoginForm() {
     const { register, handleSubmit } = useForm()
     const dispatch = useDispatch()
     const navigate = useNavigate()
@@ -66,5 +66,3 @@ function LoginForm() {
         </Box>
     )
 }
-
-export { LoginForm }

--- a/src/components/Forms/OrganizationForm/index.jsx
+++ b/src/components/Forms/OrganizationForm/index.jsx
@@ -7,7 +7,7 @@ import { useServerErrors } from '../useServerErrors'
 
 import './style.scss'
 
-function OrganizationForm() {
+export function OrganizationForm() {
     const { register, handleSubmit, setError, formState: { errors } } = useForm()
     const navigate = useNavigate()
     const [isLoading, setIsLoading] = useState(false)
@@ -69,5 +69,3 @@ function OrganizationForm() {
         </div>
     )
 }
-
-export { OrganizationForm }

--- a/src/components/Forms/PostForm/index.jsx
+++ b/src/components/Forms/PostForm/index.jsx
@@ -5,7 +5,7 @@ import SendIcon from '@mui/icons-material/Send'
 import { createPost } from '../../../redux/thunks/feed'
 import './style.scss'
 
-function PostForm() {
+export function PostForm() {
     const { register, handleSubmit, reset } = useForm()
 
     const dispatch = useDispatch()
@@ -39,5 +39,3 @@ function PostForm() {
         </Paper>
     )
 }
-
-export { PostForm }

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -13,7 +13,7 @@ import { ErrorCode, setErrorPage } from '../../../redux/reducers/errorPage'
 
 import './style.scss'
 
-function ProfileForm() {
+export function ProfileForm() {
     const dispatch = useDispatch()
     const navigate = useNavigate()
     const location = useLocation()
@@ -409,5 +409,3 @@ function ProfileForm() {
         </Box>
     )
 }
-
-export { ProfileForm }

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -6,7 +6,7 @@ import './style.scss'
 
 // TODO si l'utilisateur est sur les pages en connecter , ne plus afficher le bouton retour
 
-function Header({ className }) {
+export function Header({ className }) {
     return (
         <AppBar className={className}>
             <Toolbar className="c-header__toolbar">
@@ -21,5 +21,3 @@ function Header({ className }) {
 Header.propTypes = {
     className: PropTypes.string
 }
-
-export { Header }

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -6,6 +6,10 @@ import './style.scss'
 
 // TODO si l'utilisateur est sur les pages en connecter , ne plus afficher le bouton retour
 
+Header.propTypes = {
+    className: PropTypes.string
+}
+
 export function Header({ className }) {
     return (
         <AppBar className={className}>
@@ -16,8 +20,4 @@ export function Header({ className }) {
             </Toolbar>
         </AppBar>
     )
-}
-
-Header.propTypes = {
-    className: PropTypes.string
 }

--- a/src/components/Nav/ButtonHome/index.jsx
+++ b/src/components/Nav/ButtonHome/index.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import { useSelector } from 'react-redux'
 import { Link, useLocation } from 'react-router-dom'
 import Button from '@mui/material/Button'
@@ -65,8 +64,4 @@ export function ButtonHome() {
             )}
         </Box>
     )
-}
-
-ButtonHome.propTypes = {
-    open: PropTypes.func
 }

--- a/src/components/Nav/DesktopMenu/index.jsx
+++ b/src/components/Nav/DesktopMenu/index.jsx
@@ -9,7 +9,7 @@ import ForumIcon from '@mui/icons-material/Forum'
 import { logout } from '../../../redux/reducers/user'
 import { getUserId, getIsAdmin, getUserOrganizationId } from '../../../redux/selectors/user'
 
-function DesktopMenu() {
+export function DesktopMenu() {
     const dispatch = useDispatch()
     const navigate = useNavigate()
     const organizationId = useSelector(getUserOrganizationId)
@@ -62,5 +62,3 @@ function DesktopMenu() {
         </List>
     )
 }
-
-export { DesktopMenu }

--- a/src/components/Nav/index.jsx
+++ b/src/components/Nav/index.jsx
@@ -2,7 +2,7 @@ import { ButtonHome } from './ButtonHome'
 import { MobileMenu } from './MobileMenu'
 import './style.scss'
 
-function Nav() {
+export function Nav() {
     return (
         <>
             <ButtonHome />
@@ -11,5 +11,3 @@ function Nav() {
 
     )
 }
-
-export { Nav }

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -27,7 +27,7 @@ const ExpandMore = styled(props => {
     })
 }))
 
-function Post({ id, author, text, commentsCount, createdAt }) {
+export function Post({ id, author, text, commentsCount, createdAt }) {
     // Date and time reformatting
     const date = moment(createdAt).format('DD/MM/YYYY')
     const time = moment(createdAt).format('HH[h]mm')
@@ -184,5 +184,3 @@ Post.propTypes = {
     createdAt: PropTypes.string,
     commentsCount: PropTypes.number
 }
-
-export { Post }

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -27,6 +27,14 @@ const ExpandMore = styled(props => {
     })
 }))
 
+Post.propTypes = {
+    id: PropTypes.number,
+    author: PropTypes.object,
+    text: PropTypes.string,
+    createdAt: PropTypes.string,
+    commentsCount: PropTypes.number
+}
+
 export function Post({ id, author, text, commentsCount, createdAt }) {
     // Date and time reformatting
     const date = moment(createdAt).format('DD/MM/YYYY')
@@ -175,12 +183,4 @@ export function Post({ id, author, text, commentsCount, createdAt }) {
             </Collapse>
         </Card>
     )
-}
-
-Post.propTypes = {
-    id: PropTypes.number,
-    author: PropTypes.object,
-    text: PropTypes.string,
-    createdAt: PropTypes.string,
-    commentsCount: PropTypes.number
 }

--- a/src/components/PostReactionsCounter/index.jsx
+++ b/src/components/PostReactionsCounter/index.jsx
@@ -17,7 +17,7 @@ const SmallAvatar = styled(Avatar)(({ theme }) => ({
     padding: 2
 }))
 
-function PostReactionsCounter({ postId }) {
+export function PostReactionsCounter({ postId }) {
     const [anchorEl, setAnchorEl] = useState(null)
     const postReactions = useSelector(getPostReactions(postId))
     const organizationId = useSelector(getUserOrganizationId)
@@ -104,5 +104,3 @@ function PostReactionsCounter({ postId }) {
 PostReactionsCounter.propTypes = {
     postId: PropTypes.number.isRequired
 }
-
-export { PostReactionsCounter }

--- a/src/components/PostReactionsCounter/index.jsx
+++ b/src/components/PostReactionsCounter/index.jsx
@@ -17,6 +17,10 @@ const SmallAvatar = styled(Avatar)(({ theme }) => ({
     padding: 2
 }))
 
+PostReactionsCounter.propTypes = {
+    postId: PropTypes.number.isRequired
+}
+
 export function PostReactionsCounter({ postId }) {
     const [anchorEl, setAnchorEl] = useState(null)
     const postReactions = useSelector(getPostReactions(postId))
@@ -99,8 +103,4 @@ export function PostReactionsCounter({ postId }) {
             </Popover>
         </>
     )
-}
-
-PostReactionsCounter.propTypes = {
-    postId: PropTypes.number.isRequired
 }

--- a/src/components/Router/ConditionalRoute/AdminRoute.jsx
+++ b/src/components/Router/ConditionalRoute/AdminRoute.jsx
@@ -4,6 +4,11 @@ import { getIsAdmin } from '../../../redux/selectors/user'
 import { ErrorCode, setErrorPage } from '../../../redux/reducers/errorPage'
 import { ConditionalRoute } from '.'
 
+AdminRoute.propTypes = {
+    redirectTo: PropTypes.string,
+    children: PropTypes.node
+}
+
 export function AdminRoute({ redirectTo, children }) {
     const dispatch = useDispatch()
     const isAdmin = useSelector(getIsAdmin)
@@ -17,9 +22,4 @@ export function AdminRoute({ redirectTo, children }) {
             {children}
         </ConditionalRoute>
     )
-}
-
-AdminRoute.propTypes = {
-    redirectTo: PropTypes.string,
-    children: PropTypes.node
 }

--- a/src/components/Router/ConditionalRoute/AuthenticatedRoute.jsx
+++ b/src/components/Router/ConditionalRoute/AuthenticatedRoute.jsx
@@ -4,6 +4,11 @@ import { getIsLogged } from '../../../redux/selectors/user'
 import { ErrorCode, setErrorPage } from '../../../redux/reducers/errorPage'
 import { ConditionalRoute } from '.'
 
+AuthenticatedRoute.propTypes = {
+    redirectTo: PropTypes.string,
+    children: PropTypes.node
+}
+
 export function AuthenticatedRoute({ redirectTo, children }) {
     const dispatch = useDispatch()
     const isLog = useSelector(getIsLogged)
@@ -17,9 +22,4 @@ export function AuthenticatedRoute({ redirectTo, children }) {
             {children}
         </ConditionalRoute>
     )
-}
-
-AuthenticatedRoute.propTypes = {
-    redirectTo: PropTypes.string,
-    children: PropTypes.node
 }

--- a/src/components/Router/ConditionalRoute/GuestRoute.jsx
+++ b/src/components/Router/ConditionalRoute/GuestRoute.jsx
@@ -4,6 +4,11 @@ import { getIsLogged } from '../../../redux/selectors/user'
 import { ErrorCode, setErrorPage } from '../../../redux/reducers/errorPage'
 import { ConditionalRoute } from '.'
 
+GuestRoute.propTypes = {
+    redirectTo: PropTypes.string,
+    children: PropTypes.node
+}
+
 export function GuestRoute({ redirectTo, children }) {
     const dispatch = useDispatch()
     const isLog = useSelector(getIsLogged)
@@ -17,9 +22,4 @@ export function GuestRoute({ redirectTo, children }) {
             {children}
         </ConditionalRoute>
     )
-}
-
-GuestRoute.propTypes = {
-    redirectTo: PropTypes.string,
-    children: PropTypes.node
 }

--- a/src/components/Router/ConditionalRoute/index.jsx
+++ b/src/components/Router/ConditionalRoute/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-function ConditionalRoute({ condition, onError, redirectTo, children }) {
+export function ConditionalRoute({ condition, onError, redirectTo, children }) {
     const navigate = useNavigate()
 
     // A useEffect is required here to dispatch the action AFTER the rendering
@@ -25,5 +25,3 @@ ConditionalRoute.propTypes = {
     redirectTo: PropTypes.string,
     children: PropTypes.node.isRequired
 }
-
-export { ConditionalRoute }

--- a/src/components/Router/ConditionalRoute/index.jsx
+++ b/src/components/Router/ConditionalRoute/index.jsx
@@ -2,6 +2,13 @@ import PropTypes from 'prop-types'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+ConditionalRoute.propTypes = {
+    condition: PropTypes.bool.isRequired,
+    onError: PropTypes.func,
+    redirectTo: PropTypes.string,
+    children: PropTypes.node.isRequired
+}
+
 export function ConditionalRoute({ condition, onError, redirectTo, children }) {
     const navigate = useNavigate()
 
@@ -17,11 +24,4 @@ export function ConditionalRoute({ condition, onError, redirectTo, children }) {
     })
 
     return condition && children
-}
-
-ConditionalRoute.propTypes = {
-    condition: PropTypes.bool.isRequired,
-    onError: PropTypes.func,
-    redirectTo: PropTypes.string,
-    children: PropTypes.node.isRequired
 }

--- a/src/components/Router/ErrorPageHandler.jsx
+++ b/src/components/Router/ErrorPageHandler.jsx
@@ -9,6 +9,10 @@ import { Error404 } from '../../views/Error404'
 import { Error500 } from '../../views/Error500'
 import { setErrorPage } from '../../redux/reducers/errorPage'
 
+ErrorPageHandler.propTypes = {
+    children: PropTypes.node.isRequired
+}
+
 export function ErrorPageHandler({ children }) {
     const dispatch = useDispatch()
     const { pathname } = useLocation()
@@ -38,8 +42,4 @@ export function ErrorPageHandler({ children }) {
         default:
             return children
     }
-}
-
-ErrorPageHandler.propTypes = {
-    children: PropTypes.node.isRequired
 }

--- a/src/components/Router/ErrorPageHandler.jsx
+++ b/src/components/Router/ErrorPageHandler.jsx
@@ -9,7 +9,7 @@ import { Error404 } from '../../views/Error404'
 import { Error500 } from '../../views/Error500'
 import { setErrorPage } from '../../redux/reducers/errorPage'
 
-function ErrorPageHandler({ children }) {
+export function ErrorPageHandler({ children }) {
     const dispatch = useDispatch()
     const { pathname } = useLocation()
     const [previousPathname, setPreviousPathname] = useState(pathname)
@@ -43,5 +43,3 @@ function ErrorPageHandler({ children }) {
 ErrorPageHandler.propTypes = {
     children: PropTypes.node.isRequired
 }
-
-export { ErrorPageHandler }

--- a/src/components/Router/NotFoundRoute.jsx
+++ b/src/components/Router/NotFoundRoute.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { ErrorCode, setErrorPage } from '../../redux/reducers/errorPage'
 
-function NotFoundRoute() {
+export function NotFoundRoute() {
     const dispatch = useDispatch()
 
     // A useEffect is required here to dispatch the action AFTER the rendering
@@ -15,5 +15,3 @@ function NotFoundRoute() {
 
     return null
 }
-
-export { NotFoundRoute }

--- a/src/components/Router/OrganizationRouteValidator.jsx
+++ b/src/components/Router/OrganizationRouteValidator.jsx
@@ -1,11 +1,9 @@
 import { Outlet, useParams } from 'react-router-dom'
 import { NotFoundRoute } from './NotFoundRoute'
 
-function OrganizationRouteValidator() {
+export function OrganizationRouteValidator() {
     const { organizationId } = useParams()
     const isValid = /^\d+$/.test(organizationId)
 
     return isValid ? <Outlet /> : <NotFoundRoute />
 }
-
-export { OrganizationRouteValidator }

--- a/src/components/ScrollToTop/index.jsx
+++ b/src/components/ScrollToTop/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 
-function ScrollToTop() {
+export function ScrollToTop() {
     const { pathname } = useLocation()
 
     useEffect(() => {
@@ -10,5 +10,3 @@ function ScrollToTop() {
 
     return null
 }
-
-export { ScrollToTop }

--- a/src/components/Themes/index.jsx
+++ b/src/components/Themes/index.jsx
@@ -1,6 +1,6 @@
 import { createTheme } from '@mui/material/styles'
 
-const Theme = createTheme({
+export const Theme = createTheme({
     components: {
         MuiButton: {
             styleOverrides: {
@@ -67,5 +67,3 @@ const Theme = createTheme({
         }
     }
 })
-
-export { Theme }

--- a/src/layout/AuthenticatedLayout/index.jsx
+++ b/src/layout/AuthenticatedLayout/index.jsx
@@ -9,6 +9,10 @@ import './style.scss'
 
 const drawerWidth = 240
 
+AuthenticatedLayout.propTypes = {
+    children: PropTypes.node
+}
+
 export function AuthenticatedLayout({ children }) {
     return (
 
@@ -45,8 +49,4 @@ export function AuthenticatedLayout({ children }) {
             <Footer />
         </Box>
     )
-}
-
-AuthenticatedLayout.propTypes = {
-    children: PropTypes.node
 }

--- a/src/layout/AuthenticatedLayout/index.jsx
+++ b/src/layout/AuthenticatedLayout/index.jsx
@@ -9,7 +9,7 @@ import './style.scss'
 
 const drawerWidth = 240
 
-function AuthenticatedLayout({ children }) {
+export function AuthenticatedLayout({ children }) {
     return (
 
         <Box>
@@ -50,5 +50,3 @@ function AuthenticatedLayout({ children }) {
 AuthenticatedLayout.propTypes = {
     children: PropTypes.node
 }
-
-export { AuthenticatedLayout }

--- a/src/layout/DoublePageLayout/index.jsx
+++ b/src/layout/DoublePageLayout/index.jsx
@@ -4,6 +4,10 @@ import { Footer } from '../../components/Footer'
 import { Header } from '../../components/Header'
 import './style.scss'
 
+DoublePageLayout.propTypes = {
+    children: PropTypes.node.isRequired
+}
+
 export function DoublePageLayout({ children }) {
     return (
         <Grid container>
@@ -26,8 +30,4 @@ export function DoublePageLayout({ children }) {
             </Grid>
         </Grid>
     )
-}
-
-DoublePageLayout.propTypes = {
-    children: PropTypes.node.isRequired
 }

--- a/src/layout/DoublePageLayout/index.jsx
+++ b/src/layout/DoublePageLayout/index.jsx
@@ -4,7 +4,7 @@ import { Footer } from '../../components/Footer'
 import { Header } from '../../components/Header'
 import './style.scss'
 
-function DoublePageLayout({ children }) {
+export function DoublePageLayout({ children }) {
     return (
         <Grid container>
             <Grid item md={6} lg={6} sx={{ display: { xs: 'none', sm: 'none', md: 'block' } }}>
@@ -31,5 +31,3 @@ function DoublePageLayout({ children }) {
 DoublePageLayout.propTypes = {
     children: PropTypes.node.isRequired
 }
-
-export { DoublePageLayout }

--- a/src/layout/Error/index.jsx
+++ b/src/layout/Error/index.jsx
@@ -3,7 +3,7 @@ import { Box } from '@mui/material'
 import { SimplePageLayout } from '../SimplePageLayout'
 import './style.scss'
 
-function Error({ code, message, image }) {
+export function Error({ code, message, image }) {
     return (
         <SimplePageLayout>
             <Box className="c-error">
@@ -25,4 +25,3 @@ Error.propTypes = {
     image: PropTypes.string.isRequired
 
 }
-export { Error }

--- a/src/layout/Error/index.jsx
+++ b/src/layout/Error/index.jsx
@@ -3,6 +3,12 @@ import { Box } from '@mui/material'
 import { SimplePageLayout } from '../SimplePageLayout'
 import './style.scss'
 
+Error.propTypes = {
+    code: PropTypes.number.isRequired,
+    message: PropTypes.string.isRequired,
+    image: PropTypes.string.isRequired
+}
+
 export function Error({ code, message, image }) {
     return (
         <SimplePageLayout>
@@ -17,11 +23,4 @@ export function Error({ code, message, image }) {
             </Box>
         </SimplePageLayout>
     )
-}
-
-Error.propTypes = {
-    code: PropTypes.number.isRequired,
-    message: PropTypes.string.isRequired,
-    image: PropTypes.string.isRequired
-
 }

--- a/src/layout/LoadingLayout/index.jsx
+++ b/src/layout/LoadingLayout/index.jsx
@@ -1,7 +1,7 @@
 import { Box, CircularProgress } from '@mui/material'
 import { Logo } from '../../components/Header/Logo'
 
-function LoadingLayout() {
+export function LoadingLayout() {
     return (
         <Box sx={{
             height: '100vh',
@@ -15,5 +15,3 @@ function LoadingLayout() {
         </Box>
     )
 }
-
-export { LoadingLayout }

--- a/src/layout/SimplePageLayout/index.jsx
+++ b/src/layout/SimplePageLayout/index.jsx
@@ -4,6 +4,10 @@ import { Footer } from '../../components/Footer'
 import { Header } from '../../components/Header'
 import './style.scss'
 
+SimplePageLayout.propTypes = {
+    children: PropTypes.node
+}
+
 export function SimplePageLayout({ children }) {
     return (
         <Grid>
@@ -16,8 +20,4 @@ export function SimplePageLayout({ children }) {
             </Box>
         </Grid>
     )
-}
-
-SimplePageLayout.propTypes = {
-    children: PropTypes.node
 }

--- a/src/layout/SimplePageLayout/index.jsx
+++ b/src/layout/SimplePageLayout/index.jsx
@@ -4,7 +4,7 @@ import { Footer } from '../../components/Footer'
 import { Header } from '../../components/Header'
 import './style.scss'
 
-function SimplePageLayout({ children }) {
+export function SimplePageLayout({ children }) {
     return (
         <Grid>
             <Box className="c-simple-page">
@@ -21,5 +21,3 @@ function SimplePageLayout({ children }) {
 SimplePageLayout.propTypes = {
     children: PropTypes.node
 }
-
-export { SimplePageLayout }

--- a/src/redux/store/index.js
+++ b/src/redux/store/index.js
@@ -9,9 +9,7 @@ const reducer = {
     feed
 }
 
-const store = configureStore({
+export const store = configureStore({
     reducer,
     devTools: true
 })
-
-export { store }

--- a/src/views/ActivityFeed/index.jsx
+++ b/src/views/ActivityFeed/index.jsx
@@ -4,7 +4,7 @@ import { AuthenticatedLayout } from '../../layout/AuthenticatedLayout'
 
 import './style.scss'
 
-function ActivityFeed() {
+export function ActivityFeed() {
     return (
 
         <AuthenticatedLayout>
@@ -14,5 +14,3 @@ function ActivityFeed() {
 
     )
 }
-
-export { ActivityFeed }

--- a/src/views/Administration/index.jsx
+++ b/src/views/Administration/index.jsx
@@ -3,7 +3,7 @@ import { AdminMembers } from '../../components/Admin/AdminMembers'
 import { ScrollTopButton } from '../../components/Buttons/ScrollTopButton'
 import './style.scss'
 
-function Administration() {
+export function Administration() {
     return (
         <AuthenticatedLayout>
             <AdminMembers />
@@ -11,5 +11,3 @@ function Administration() {
         </AuthenticatedLayout>
     )
 }
-
-export { Administration }

--- a/src/views/Contact/index.jsx
+++ b/src/views/Contact/index.jsx
@@ -4,7 +4,7 @@ import { SimplePageLayout } from '../../layout/SimplePageLayout'
 
 import './style.scss'
 
-function Contact() {
+export function Contact() {
     const theme = useTheme()
     const handleClick = () => {
         const contactEmail = 'contact@onetwork.com' // TODO Change email
@@ -205,5 +205,3 @@ function Contact() {
         </SimplePageLayout>
     )
 }
-
-export { Contact }

--- a/src/views/Error401/index.jsx
+++ b/src/views/Error401/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import { Error } from '../../layout/Error'
 
-function Error401({ message = `Accès refusé : Vous devez être connecté pour accéder à cette page.` }) {
+export function Error401({ message = `Accès refusé : Vous devez être connecté pour accéder à cette page.` }) {
     return (
         <Error
             code={401}
@@ -15,5 +15,3 @@ Error401.propTypes = {
     message: PropTypes.string
 
 }
-
-export { Error401 }

--- a/src/views/Error401/index.jsx
+++ b/src/views/Error401/index.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types'
 import { Error } from '../../layout/Error'
 
+Error401.propTypes = {
+    message: PropTypes.string
+}
+
 export function Error401({ message = `Accès refusé : Vous devez être connecté pour accéder à cette page.` }) {
     return (
         <Error
@@ -9,9 +13,4 @@ export function Error401({ message = `Accès refusé : Vous devez être connect�
             image="/assets/errors/closedoor401.jpg"
         />
     )
-}
-
-Error401.propTypes = {
-    message: PropTypes.string
-
 }

--- a/src/views/Error403/index.jsx
+++ b/src/views/Error403/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import { Error } from '../../layout/Error'
 
-function Error403({ message = `Désolé, vous n'avez pas l'autorisation d'accéder à cette page.` }) {
+export function Error403({ message = `Désolé, vous n'avez pas l'autorisation d'accéder à cette page.` }) {
     return (
         <Error
             code={403}
@@ -15,5 +15,3 @@ Error403.propTypes = {
     message: PropTypes.string
 
 }
-
-export { Error403 }

--- a/src/views/Error403/index.jsx
+++ b/src/views/Error403/index.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types'
 import { Error } from '../../layout/Error'
 
+Error403.propTypes = {
+    message: PropTypes.string
+}
+
 export function Error403({ message = `Désolé, vous n'avez pas l'autorisation d'accéder à cette page.` }) {
     return (
         <Error
@@ -9,9 +13,4 @@ export function Error403({ message = `Désolé, vous n'avez pas l'autorisation d
             image="/assets/errors/interdit403.jpg"
         />
     )
-}
-
-Error403.propTypes = {
-    message: PropTypes.string
-
 }

--- a/src/views/Error404/index.jsx
+++ b/src/views/Error404/index.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types'
 import { Error } from '../../layout/Error'
 
+Error404.propTypes = {
+    message: PropTypes.string
+}
+
 export function Error404({ message = `La page que vous recherchez est perdue dans l'espace.` }) {
     return (
         <Error
@@ -9,9 +13,4 @@ export function Error404({ message = `La page que vous recherchez est perdue dan
             image="/assets/errors/espace404.jpg"
         />
     )
-}
-
-Error404.propTypes = {
-    message: PropTypes.string
-
 }

--- a/src/views/Error404/index.jsx
+++ b/src/views/Error404/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import { Error } from '../../layout/Error'
 
-function Error404({ message = `La page que vous recherchez est perdue dans l'espace.` }) {
+export function Error404({ message = `La page que vous recherchez est perdue dans l'espace.` }) {
     return (
         <Error
             code={404}
@@ -15,5 +15,3 @@ Error404.propTypes = {
     message: PropTypes.string
 
 }
-
-export { Error404 }

--- a/src/views/Error500/index.jsx
+++ b/src/views/Error500/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import { Error } from '../../layout/Error'
 
-function Error500({ message = `Oups ! Quelque chose s'est mal passé de notre côté. Veuillez réessayer plus tard.` }) {
+export function Error500({ message = `Oups ! Quelque chose s'est mal passé de notre côté. Veuillez réessayer plus tard.` }) {
     return (
         <Error
             code={500}
@@ -15,5 +15,3 @@ Error500.propTypes = {
     message: PropTypes.string
 
 }
-
-export { Error500 }

--- a/src/views/Error500/index.jsx
+++ b/src/views/Error500/index.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types'
 import { Error } from '../../layout/Error'
 
+Error500.propTypes = {
+    message: PropTypes.string
+}
+
 export function Error500({ message = `Oups ! Quelque chose s'est mal passé de notre côté. Veuillez réessayer plus tard.` }) {
     return (
         <Error
@@ -9,9 +13,4 @@ export function Error500({ message = `Oups ! Quelque chose s'est mal passé de n
             image="/assets/errors/cable500.jpg"
         />
     )
-}
-
-Error500.propTypes = {
-    message: PropTypes.string
-
 }

--- a/src/views/Home/index.jsx
+++ b/src/views/Home/index.jsx
@@ -5,7 +5,7 @@ import { LoginForm } from '../../components/Forms/LoginForm'
 
 import './style.scss'
 
-function Home() {
+export function Home() {
     return (
         <SimplePageLayout>
             <Box className="c-home"
@@ -36,5 +36,3 @@ function Home() {
         </SimplePageLayout>
     )
 }
-
-export { Home }

--- a/src/views/OrganizationCreation/index.jsx
+++ b/src/views/OrganizationCreation/index.jsx
@@ -3,12 +3,10 @@ import { DoublePageLayout } from '../../layout/DoublePageLayout'
 
 import './style.scss'
 
-function OrganizationCreation() {
+export function OrganizationCreation() {
     return (
         <DoublePageLayout>
             <OrganizationForm />
         </DoublePageLayout>
     )
 }
-
-export { OrganizationCreation }

--- a/src/views/ProfileSettings/index.jsx
+++ b/src/views/ProfileSettings/index.jsx
@@ -3,7 +3,7 @@ import { DoublePageLayout } from '../../layout/DoublePageLayout'
 
 import './style.scss'
 
-function ProfileSettings() {
+export function ProfileSettings() {
     return (
 
         <DoublePageLayout>
@@ -11,4 +11,3 @@ function ProfileSettings() {
         </DoublePageLayout>
     )
 }
-export { ProfileSettings }

--- a/src/views/SignUp/index.jsx
+++ b/src/views/SignUp/index.jsx
@@ -3,12 +3,10 @@ import { DoublePageLayout } from '../../layout/DoublePageLayout'
 
 import './style.scss'
 
-function SignUp() {
+export function SignUp() {
     return (
         <DoublePageLayout>
             <ProfileForm />
         </DoublePageLayout>
     )
 }
-
-export { SignUp }

--- a/src/views/UserProfile/index.jsx
+++ b/src/views/UserProfile/index.jsx
@@ -4,7 +4,7 @@ import { ScrollTopButton } from '../../components/Buttons/ScrollTopButton'
 import { AuthenticatedLayout } from '../../layout/AuthenticatedLayout'
 import './style.scss'
 
-function UserProfile() {
+export function UserProfile() {
     const { userId } = useParams()
 
     return (
@@ -16,5 +16,3 @@ function UserProfile() {
 
     )
 }
-
-export { UserProfile }


### PR DESCRIPTION
> [<img alt="JonGarbayo" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/11503863?s=40&v=4">](/JonGarbayo) **Authored by [JonGarbayo](/JonGarbayo)**
_<time datetime="2025-02-18T12:19:14Z" title="Tuesday, February 18th 2025, 1:19:14 pm +01:00">Feb 18, 2025</time>_
_Merged <time datetime="2025-02-18T12:41:43Z" title="Tuesday, February 18th 2025, 1:41:43 pm +01:00">Feb 18, 2025</time>_
---

The previous #170 PR used ESLint to fix most of the inconsistencies in the codebase, but some rules just don't exist. That's the case for the placement of the `PropTypes` definitions in component files or the use of inline exports instead of end-of-file exports.

In this PR, all `PropTypes` definitions are declared above component definitions for better readability, and all exports now use inline named syntax wherever possible for consistency. These changes harmonize the codebase, making it more professional.